### PR TITLE
Updated the tests with a tearDown method.

### DIFF
--- a/aliss/tests/models/test_category.py
+++ b/aliss/tests/models/test_category.py
@@ -38,3 +38,6 @@ class CategoryTestCase(TestCase):
         c.delete()
         indexed_service = get_service(queryset, self.service.id)[0]
         self.assertEqual(len(indexed_service['categories']), 0)
+
+    def tearDown(self):
+        Service.objects.get(name="My First Service").delete()

--- a/aliss/tests/models/test_organisation.py
+++ b/aliss/tests/models/test_organisation.py
@@ -37,3 +37,7 @@ class OrganisationTestCase(TestCase):
         queryset = Fixtures.es_connection()
         indexed_service = get_service(queryset, self.service.id)[0]
         self.assertEqual(indexed_service['organisation']['name'], self.org.name)
+
+    def tearDown(self):
+        for service in Service.objects.filter(name="My First Service"):
+            service.delete()

--- a/aliss/tests/models/test_service.py
+++ b/aliss/tests/models/test_service.py
@@ -79,3 +79,7 @@ class ServiceTestCase(TestCase):
         s = Service.objects.get(name="My First Service")
         s.save(kwargs={'skip_index': True})
         self.assertTrue(isinstance(s, Service))
+
+    def tearDown(self):
+        for service in Service.objects.filter(name="My First Service"):
+            service.delete()

--- a/aliss/tests/views/test_search_view.py
+++ b/aliss/tests/views/test_search_view.py
@@ -22,3 +22,6 @@ class SearchViewTestCase(TestCase):
         response = self.client.get('/search/?postcode=G2+4AA')
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Help &amp; support in <span class="postcode">G2 4AA</span>')
+
+    def tearDown(self):
+        Service.objects.get(name="My First Service").delete()

--- a/aliss/tests/views/test_service_view.py
+++ b/aliss/tests/views/test_service_view.py
@@ -61,3 +61,6 @@ class ServiceViewTestCase(TestCase):
         self.assertEqual(service.name, 'an updated service')
         self.assertEqual(service.updated_by, self.user)
         self.assertEqual(response.status_code, 302)
+
+    def tearDown(self):
+        Service.objects.get(name="My First Service").delete()

--- a/aliss/tests/views/test_service_view.py
+++ b/aliss/tests/views/test_service_view.py
@@ -63,4 +63,4 @@ class ServiceViewTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
 
     def tearDown(self):
-        Service.objects.get(name="My First Service").delete()
+        Service.objects.filter(name="My First Service").delete()


### PR DESCRIPTION
Found that elastic search was being filled with test services as they were in the setup but there were no ```tearDown``` methods. Added them to all necessary tests so that the "My First Service" test service is deleted on completion. https://github.com/Mike-Heneghan/ALISS/issues/13