### PR TITLE
Enhance/your last search

### DIFF
--- a/aliss/templates/account/base.html
+++ b/aliss/templates/account/base.html
@@ -71,24 +71,40 @@
       if (searchURL != null){
         query_section = searchURL.split('?')
         query_section = query_section[1]
-        console.log(query_section)
         query_section = query_section.replace(/\+/gi, " ")
         query_section = query_section.replace(/-/gi, " ")
         query_section = query_section.split('&')
-        console.log(query_section)
         query_section.every(function(query){
           query_pair = query.split("=")
           if (query_pair[1] != "") {
+
+            if (query_pair[1].includes(" ")){
+              query_pair[1] = query_pair[1].trim()
+              uncapped_words = query_pair[1].split(" ")
+              capped_words = uncapped_words.map(function(word){
+                if (word == "and") {
+                  return word
+                }
+                else {
+                word =  word[0].toUpperCase() + word.slice(1)
+                return word
+                }
+              })
+              capped_words = capped_words.join(" ")
+              hash[query_pair[0]] = capped_words
+            }
+          else {
             hash[query_pair[0]] = query_pair[1][0].toUpperCase() + query_pair[1].slice(1)
-          }
+            }
+        }
           return hash
         })
         last_search_string = hash['postcode']
         if (hash['category']){
-          last_search_string = last_search_string + " and " + hash['category']
+          last_search_string = last_search_string + " and \"" + hash['category'] + "\""
         }
         if (hash['q']){
-          last_search_string = last_search_string + " for " + hash['q']
+          last_search_string = last_search_string + " for \"" + hash['q'] + "\""
         }
       $('#last_search_link').attr('href', searchURL)
       $('#last_search_link').text(last_search_string)

--- a/aliss/templates/account/base.html
+++ b/aliss/templates/account/base.html
@@ -10,6 +10,7 @@
                     <a href="{% url 'account_update' %}" class="button primary">Edit Account Info</a>
                 </div>
                 {% if request.user.postcode %}<p>Your postcode: <strong>{{ request.user.postcode }}</strong></p>{% endif %}
+                <p id="your_last_search" style="display:none">Your last search: <strong><a id="last_search_link"></a></strong></p>
             </div>
         </div>
     </section>
@@ -60,3 +61,17 @@
     </section>
 </main>
 {% endblock %}
+
+
+{% block before_body_close %}
+  <script type="text/javascript">
+    $(document).ready(function(){
+      searchURL = localStorage.getItem('searchURL')
+      if (searchURL != null){
+        $('#last_search_link').attr('href', searchURL)
+        $('#last_search_link').text('test test test')
+        $('#your_last_search').show()
+      }
+    })
+  </script>
+{% endblock%}

--- a/aliss/templates/account/base.html
+++ b/aliss/templates/account/base.html
@@ -71,21 +71,27 @@
       if (searchURL != null){
         query_section = searchURL.split('?')
         query_section = query_section[1]
-        query_section = query_section.replace("+", " ")
-        query_section = query_section.replace("-", " ")
+        console.log(query_section)
+        query_section = query_section.replace(/\+/gi, " ")
+        query_section = query_section.replace(/-/gi, " ")
         query_section = query_section.split('&')
         console.log(query_section)
         query_section.every(function(query){
           query_pair = query.split("=")
           if (query_pair[1] != "") {
             hash[query_pair[0]] = query_pair[1][0].toUpperCase() + query_pair[1].slice(1)
-            console.log(query_pair)
-            console.log(hash)
           }
           return hash
         })
+        last_search_string = hash['postcode']
+        if (hash['category']){
+          last_search_string = last_search_string + " and " + hash['category']
+        }
+        if (hash['q']){
+          last_search_string = last_search_string + " for " + hash['q']
+        }
       $('#last_search_link').attr('href', searchURL)
-      $('#last_search_link').text(hash['postcode'] + " and " + hash['category'] + " for "+ hash['q'])
+      $('#last_search_link').text(last_search_string)
       $('#your_last_search').show()
       }
     })

--- a/aliss/templates/account/base.html
+++ b/aliss/templates/account/base.html
@@ -67,10 +67,26 @@
   <script type="text/javascript">
     $(document).ready(function(){
       searchURL = localStorage.getItem('searchURL')
+      var hash = {}
       if (searchURL != null){
-        $('#last_search_link').attr('href', searchURL)
-        $('#last_search_link').text('test test test')
-        $('#your_last_search').show()
+        query_section = searchURL.split('?')
+        query_section = query_section[1]
+        query_section = query_section.replace("+", " ")
+        query_section = query_section.replace("-", " ")
+        query_section = query_section.split('&')
+        console.log(query_section)
+        query_section.every(function(query){
+          query_pair = query.split("=")
+          if (query_pair[1] != "") {
+            hash[query_pair[0]] = query_pair[1][0].toUpperCase() + query_pair[1].slice(1)
+            console.log(query_pair)
+            console.log(hash)
+          }
+          return hash
+        })
+      $('#last_search_link').attr('href', searchURL)
+      $('#last_search_link').text(hash['postcode'] + " and " + hash['category'] + " for "+ hash['q'])
+      $('#your_last_search').show()
       }
     })
   </script>

--- a/aliss/templates/base.html
+++ b/aliss/templates/base.html
@@ -82,7 +82,14 @@
 
     {% block base_js %}
       <script>
-        $(document).ready(function(){$('.top-hat').append("<h1>bla bla bla</h1>")})
+        $(document).ready(function(){
+          locationURL = $(location).attr('href')
+          console.log("hit")
+          if (locationURL.includes('search')){
+            localStorage.setItem('searchURL',locationURL)
+            console.log(locationURL)
+          }
+        })
       </script>
     {% endblock%}
 

--- a/aliss/templates/base.html
+++ b/aliss/templates/base.html
@@ -84,10 +84,8 @@
       <script>
         $(document).ready(function(){
           locationURL = $(location).attr('href')
-          console.log("hit")
           if (locationURL.includes('search' && 'postcode')){
             localStorage.setItem('searchURL',locationURL)
-            console.log(locationURL)
           }
         })
       </script>

--- a/aliss/templates/base.html
+++ b/aliss/templates/base.html
@@ -85,7 +85,7 @@
         $(document).ready(function(){
           locationURL = $(location).attr('href')
           console.log("hit")
-          if (locationURL.includes('search')){
+          if (locationURL.includes('search' && 'postcode')){
             localStorage.setItem('searchURL',locationURL)
             console.log(locationURL)
           }
@@ -95,5 +95,6 @@
 
     {% block before_body_close %}
     {% endblock %}
+
 </body>
 </html>

--- a/aliss/templates/base.html
+++ b/aliss/templates/base.html
@@ -79,6 +79,13 @@
 
     <!-- Javacript -->
     <script type="text/javascript" src="{% static 'js/scripts.js' %}"></script>
+
+    {% block base_js %}
+      <script>
+        $(document).ready(function(){$('.top-hat').append("<h1>bla bla bla</h1>")})
+      </script>
+    {% endblock%}
+
     {% block before_body_close %}
     {% endblock %}
 </body>

--- a/aliss/templates/organisation/detail.html
+++ b/aliss/templates/organisation/detail.html
@@ -95,6 +95,14 @@
                                 Claim this organisation
                             </a>
                         {% endif %}
+
+                        <a id="back_to_seach" class="icon-link" style = "display:none">
+                          <span class="icon">
+                            <i class="fas fa-arrow-left"></i>
+                          </span>
+                          Back To Last Search
+                        </a>
+                        
                     </div>
                 </div>
                 {% if not object.published %}
@@ -177,3 +185,14 @@
 }
 </script>
 {% endblock %}
+
+{% block before_body_close %}
+  <script type="text/javascript">
+    $(document).ready(function(){
+      searchURL = localStorage.getItem('searchURL')
+      if (searchURL != null){
+        $('#back_to_seach').attr('href', searchURL).show()
+      }
+    })
+  </script>
+{% endblock%}

--- a/aliss/templates/service/detail.html
+++ b/aliss/templates/service/detail.html
@@ -237,6 +237,8 @@
 }
 </script>
 
+{% endblock %}
+
 {% block before_body_close %}
   <script type="text/javascript">
     $(document).ready(function(){
@@ -247,5 +249,3 @@
     })
   </script>
 {% endblock%}
-
-{% endblock %}

--- a/aliss/templates/service/detail.html
+++ b/aliss/templates/service/detail.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load aliss %}
 
+
 {% block title %}{{ object.name }} {% meta_location service %} - {{ object.organisation.name }} - ALISS{% endblock %}
 {% block meta_schema %}
     <meta name="twitter:title" content="{{ object.name }} on ALISS.org" />
@@ -48,7 +49,7 @@
                         <h4 id="service_actions_toggle" class="toggle-heading">Actions</h4>
                     </div>
 
-                    <!-- 1. Email, 2. Print, 3. Recommend, 4. Remove 5. Improve. -->
+                    <!-- 1. Email, 2. Print, 3. Recommend, 4. Remove 5. Improve. 6. Back to Search -->
                     <div class="actions toggle-content">
 
                         <a class="icon-link" id="email_service_toggle">
@@ -131,6 +132,14 @@
                         <a id="report_listing" class="improve">
                             <i class="fas fa-comment"></i> Improve this listing
                         </a>
+
+                        <a id="back_to_seach" class="icon-link" style = "display:none">
+                          <span class="icon">
+                            <i class="fas fa-arrow-left"></i>
+                          </span>
+                          Back To Last Search
+                        </a>
+
                     </div>
                 </div>
             </div>
@@ -227,4 +236,16 @@
   }
 }
 </script>
+
+{% block before_body_close %}
+  <script type="text/javascript">
+    $(document).ready(function(){
+      searchURL = localStorage.getItem('searchURL')
+      if (searchURL != null){
+        $('#back_to_seach').attr('href', searchURL).show()
+      }
+    })
+  </script>
+{% endblock%}
+
 {% endblock %}


### PR DESCRIPTION
Using the localStorage variable 'SearchURL' added an extra line on the account page with a link to the last search from the user with the Postcode Category and Keyword used as per https://github.com/Mike-Heneghan/ALISS/issues/11. Wrote quite a lot of JS to process the SearchURL into a human readable link. Also kept consistent styling with the other links on the page. 

Also, this version doesn't remove special characters from the keyword search or handle categories with "&" in the name as that information is not available in the URL 

Might be worth moving the JS into the src folder?

