### PR TITLE
Enhance/validate postcode on signup if entered.

### DIFF
--- a/aliss/forms/account.py
+++ b/aliss/forms/account.py
@@ -1,10 +1,11 @@
 from django import forms
+from localflavor.gb.forms import GBPostcodeField
 from django.contrib.auth import password_validation
 from django.urls import reverse_lazy
 from django.utils.functional import lazy
 from django.utils.safestring import mark_safe
 
-from aliss.models import ALISSUser, RecommendedServiceList
+from aliss.models import ALISSUser, RecommendedServiceList, Postcode
 
 def get_accept_terms_and_conditions_label():
     return mark_safe(
@@ -21,6 +22,11 @@ class SignupForm(forms.ModelForm):
     error_messages = {
         'password_mismatch': "The two password fields didn't match.",
     }
+
+    postcode = GBPostcodeField(
+        label="Postcode",
+        required=False
+    )
 
     password1 = forms.CharField(
         label="Password",
@@ -66,6 +72,10 @@ class SignupForm(forms.ModelForm):
         self.instance.username = self.cleaned_data.get('username')
         password_validation.validate_password(self.cleaned_data.get('password2'), self.instance)
         return password2
+
+    def clean_postcode(self):
+        postcode = self.cleaned_data.get("postcode")
+        return postcode
 
 
 class AccountUpdateForm(forms.ModelForm):

--- a/aliss/forms/account.py
+++ b/aliss/forms/account.py
@@ -73,11 +73,6 @@ class SignupForm(forms.ModelForm):
         password_validation.validate_password(self.cleaned_data.get('password2'), self.instance)
         return password2
 
-    # def clean_postcode(self):
-    #     postcode = self.cleaned_data.get("postcode")
-    #     return postcode
-
-
 class AccountUpdateForm(forms.ModelForm):
     class Meta:
         model = ALISSUser

--- a/aliss/forms/account.py
+++ b/aliss/forms/account.py
@@ -73,9 +73,9 @@ class SignupForm(forms.ModelForm):
         password_validation.validate_password(self.cleaned_data.get('password2'), self.instance)
         return password2
 
-    def clean_postcode(self):
-        postcode = self.cleaned_data.get("postcode")
-        return postcode
+    # def clean_postcode(self):
+    #     postcode = self.cleaned_data.get("postcode")
+    #     return postcode
 
 
 class AccountUpdateForm(forms.ModelForm):

--- a/aliss/tests/forms/__init__.py
+++ b/aliss/tests/forms/__init__.py
@@ -1,0 +1,1 @@
+from . import *

--- a/aliss/tests/forms/test_account_form.py
+++ b/aliss/tests/forms/test_account_form.py
@@ -10,8 +10,19 @@ class SignupFormTestCase(TestCase):
         self.name = "Random"
         self.email = "random@random.org"
         self.password = "passwurd"
+        self.password_mismatch = "passwuld"
 
-    def test_form_is_valid(self):
-        request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password, 'postcode':'EH21 6UW' })
+    def test_form_is_valid_basic_user(self):
+        request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password, 'accept_terms_and_conditions':True })
         form = SignupForm(request.POST)
         self.assertEqual(form.is_valid(), True)
+
+    def test_form_is_valis_basic_user_postcode(self):
+        request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password, 'accept_terms_and_conditions':True, 'postcode':'EH21 6UW' })
+        form = SignupForm(request.POST)
+        self.assertEqual(form.is_valid(), True)
+
+    def test_form_is_invalid_basic_user_password_mismatch(self):
+        request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password_mismatch, 'accept_terms_and_conditions':True})
+        form = SignupForm(request.POST)
+        self.assertEqual(form.is_valid(), False)

--- a/aliss/tests/forms/test_account_form.py
+++ b/aliss/tests/forms/test_account_form.py
@@ -1,0 +1,17 @@
+from django.test import TestCase, RequestFactory
+from django.urls import reverse
+from aliss.models import *
+from aliss.forms import *
+
+class SignupFormTestCase(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.name = "Random"
+        self.email = "random@random.org"
+        self.password = "passwurd"
+
+    def test_form_is_valid(self):
+        request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password, 'postcode':'EH21 6UW' })
+        form = SignupForm(request.POST)
+        self.assertEqual(form.is_valid(), True)

--- a/aliss/tests/forms/test_account_form.py
+++ b/aliss/tests/forms/test_account_form.py
@@ -22,7 +22,32 @@ class SignupFormTestCase(TestCase):
         form = SignupForm(request.POST)
         self.assertEqual(form.is_valid(), True)
 
+    def test_form_is_valis_basic_user_postcode_case_insensitive(self):
+        request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password, 'accept_terms_and_conditions':True, 'postcode':'eH21 6uW' })
+        form = SignupForm(request.POST)
+        self.assertEqual(form.is_valid(), True)
+
+    def test_form_is_valis_basic_user_postcode_whitespace(self):
+        request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password, 'accept_terms_and_conditions':True, 'postcode':' EH21 6UW ' })
+        form = SignupForm(request.POST)
+        self.assertEqual(form.is_valid(), True)
+
     def test_form_is_invalid_basic_user_password_mismatch(self):
         request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password_mismatch, 'accept_terms_and_conditions':True})
+        form = SignupForm(request.POST)
+        self.assertEqual(form.is_valid(), False)
+
+    def test_form_is_invalid_basic_user_terms_not_accepted(self):
+        request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password_mismatch, 'accept_terms_and_conditions':False})
+        form = SignupForm(request.POST)
+        self.assertEqual(form.is_valid(), False)
+
+    def test_form_is_invalid_basic_user_postcode_special_character(self):
+        request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password_mismatch, 'accept_terms_and_conditions':False, 'postcode':"EH2£ 6UW"})
+        form = SignupForm(request.POST)
+        self.assertEqual(form.is_valid(), False)
+
+    def test_form_is_invalid_basic_user_postcode_too_many_characters(self):
+        request = self.factory.post(reverse('signup'), { 'name': self.name, 'email':self.email, 'password1': self.password, 'password2':self.password_mismatch, 'accept_terms_and_conditions':False, 'postcode':"EH21 6UWW"})
         form = SignupForm(request.POST)
         self.assertEqual(form.is_valid(), False)


### PR DESCRIPTION
As per https://github.com/Mike-Heneghan/ALISS/issues/7 set the SignUp form field to be a GB postcode for validation hopefully reducing spam. 

Also added tests for the signup form basic user account with postcode validation.