### PR TITLE
Test/digest post success

### DIFF
--- a/aliss/templates/account/base.html
+++ b/aliss/templates/account/base.html
@@ -9,7 +9,7 @@
         <div class="buttons">
           <a href="{% url 'account_update' %}" class="button primary">Edit account</a>
         </div>
-        <p id="your_last_search" style="display:none">Your last search: 
+        <p id="your_last_search" style="display:none">Your last search:
           <strong><a id="last_search_link"></a></strong>
         </p>
       </div>
@@ -43,14 +43,14 @@
         </a>
       </div>
       <div class="cell small-3 medium-3 large-3">
-        <!--  
+
         <a href="{% url 'account_my_digest'%}" {% if url_name == 'account_my_digest'%}class="active"{% endif %}>
           <span class="text">
             My digest
           </span>
         </a>
         {% endwith %}
-        -->
+      
       </div>
     </div>
 

--- a/aliss/templates/account/base.html
+++ b/aliss/templates/account/base.html
@@ -43,14 +43,14 @@
         </a>
       </div>
       <div class="cell small-3 medium-3 large-3">
-
-        <a href="{% url 'account_my_digest'%}" {% if url_name == 'account_my_digest'%}class="active"{% endif %}>
-          <span class="text">
-            My digest
-          </span>
-        </a>
-        {% endwith %}
-      
+        <!--
+            <a href="{% url 'account_my_digest'%}" {% if url_name == 'account_my_digest'%}class="active"{% endif %}>
+              <span class="text">
+                My digest
+              </span>
+            </a>
+            {% endwith %}
+         -->
       </div>
     </div>
 

--- a/aliss/tests/views/test_account_digest_selection.py
+++ b/aliss/tests/views/test_account_digest_selection.py
@@ -101,3 +101,4 @@ class AccountDigestSelectionViewTestCase(TestCase):
         response = self.client.delete((reverse('account_my_digest_delete', kwargs={'pk': user_digest.pk})))
         self.assertEqual(response.status_code, 302)
         self.assertEqual(self.user.digest_selections.all().count(), 0)
+        self.assertRedirects(response, (reverse('account_my_digest')))


### PR DESCRIPTION
Hi Rory,

As per https://github.com/Mike-Heneghan/ALISS/issues/2 used test_organisation_view.py as a basis for adding further tests to the digest view. Created and deleted digest_selections via client and checked they were successful and the response codes and redirects. Also deleted some unused code from test_account_digest_selections.py  

Cheers,

Mike