### PR TITLE
Updated header.scss to improve twitter icon alignment

### DIFF
--- a/src/scss/global/header.scss
+++ b/src/scss/global/header.scss
@@ -287,7 +287,7 @@ header {
 				vertical-align: bottom;
 				margin-right: 1em;
 				&:last-child {
-					margin-right: 0;
+					margin-right: 0.25em;
 				}
 				&.active {
 					a {
@@ -297,9 +297,8 @@ header {
 			}
 		}
 		ul.social {
-			margin-left: 0.25em;
 			li {
-				margin: 0;
+				margin-bottom: 0.32em;
 				a {
 					@include st {
 						text-decoration: none;
@@ -451,12 +450,12 @@ header {
 						}
 					}
 					&.social {
-						margin-top: 1rem;
+						margin-top: 0rem;
 						li {
 							display: inline-block;
 							float: none;
 							text-align: center;
-							margin: 0 0.15em;
+							margin-right: 0.2em;
 							width: 1.25em;
 							a {
 								padding: 0;


### PR DESCRIPTION
As per https://github.com/Mike-Heneghan/ALISS/issues/33 updated the `header.scss` file to improve the formatting of the twitter icon. Just a note that I had to run `gulp` rather than just `gulp scss` to get the change to take effect  🤷🏻‍♂️.