### PR TITLE
Enhance/info fourth category

### DIFF
--- a/aliss/templates/service/forms/partials/category.html
+++ b/aliss/templates/service/forms/partials/category.html
@@ -2,7 +2,7 @@
 
 <li>
     <label>
-        <input type="checkbox" name="categories" value="{{ category.pk }}" {% if category.pk in selected_categories %}checked{% endif %} data-tooltip aria-haspopup="true" class="has-tip right cat-max" data-disable-hover="true" tabindex="2" title="Test" aria-hidden="true">
+        <input type="checkbox" name="categories" value="{{ category.pk }}" {% if category.pk in selected_categories %}checked{% endif %}>
 
         {% if category.is_root %}
             <span class="cat">

--- a/aliss/templates/service/forms/partials/category.html
+++ b/aliss/templates/service/forms/partials/category.html
@@ -2,7 +2,8 @@
 
 <li>
     <label>
-        <input type="checkbox" name="categories" value="{{ category.pk }}" {% if category.pk in selected_categories %}checked{% endif %}>
+        <input type="checkbox" name="categories" value="{{ category.pk }}" {% if category.pk in selected_categories %}checked{% endif %} data-tooltip aria-haspopup="true" class="has-tip right cat-max" data-disable-hover="true" tabindex="2" title="Test" aria-hidden="true">
+
         {% if category.is_root %}
             <span class="cat">
                 <i class="fa {{ category|get_icon }}"></i>

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -104,6 +104,7 @@ $(document).ready(() => {
       }
       else {
         console.log("You can't add more categries!");
+        $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>")
       }
     } else {
       // console.log('unchecked');

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -99,7 +99,9 @@ $(document).ready(() => {
     // console.log(label);
     if($thisCheck.prop('checked')) {
       // console.log('checked');
-      $('.selected-categories .cats').append(`<div class="selected-cat" data-cat="${value}"><span class="remove"></span>${label}</div>`);
+      if($('.all-categories input:checkbox:checked').length < 3) {
+        $('.selected-categories .cats').append(`<div class="selected-cat" data-cat="${value}"><span class="remove"></span>${label}</div>`);
+      }
     } else {
       // console.log('unchecked');
       $(`.selected-categories .cats .selected-cat[data-cat='${value}']`).remove();
@@ -214,7 +216,7 @@ $(document).ready(() => {
     if (isLocationValid()){
       var endpoint = $(this).attr('data-create-endpoint');
       $('#add-location').attr('disabled', 'disabled');
-      createLocation(endpoint);  
+      createLocation(endpoint);
     }
   });
 

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -103,7 +103,7 @@ $(document).ready(() => {
         $('.selected-categories .cats').append(`<div class="selected-cat" data-cat="${value}"><span class="remove"></span>${label}</div>`);
       }
       else {
-        console.log("You can't add more categries!");
+        // console.log("You can't add more categries!");
         if (!$('.cat-warning').length){
           $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>");
         }

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -99,7 +99,7 @@ $(document).ready(() => {
     // console.log(label);
     if($thisCheck.prop('checked')) {
       // console.log('checked');
-      if($('.all-categories input:checkbox:checked').length < 3) {
+      if($('.all-categories input:checkbox:checked').length < 4) {
         $('.selected-categories .cats').append(`<div class="selected-cat" data-cat="${value}"><span class="remove"></span>${label}</div>`);
       }
     } else {

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -104,11 +104,16 @@ $(document).ready(() => {
       }
       else {
         console.log("You can't add more categries!");
-        $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>");
+        if ($('.cat-warning').length){
+          $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>");
+        }
       }
     } else {
       // console.log('unchecked');
       $(`.selected-categories .cats .selected-cat[data-cat='${value}']`).remove();
+      if ($('.cat-warning').length){
+        $('.cat-warning').remove();
+      }
     }
     $('.selected-cat span.remove').click(function(){
       var value = $(this).parent().attr('data-cat');

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -104,7 +104,7 @@ $(document).ready(() => {
       }
       else {
         console.log("You can't add more categries!");
-        if ($('.cat-warning').length){
+        if (!$('.cat-warning').length){
           $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>");
         }
       }

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -105,7 +105,7 @@ $(document).ready(() => {
       else {
         console.log("You can't add more categries!");
         if (!$('.cat-warning').length){
-          $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>")
+          $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>");
         }
       }
     } else {
@@ -121,7 +121,7 @@ $(document).ready(() => {
       $(this).parent().remove();
       if ($('.cat-warning').length){
         $('.cat-warning').remove();
-      };
+      }
       $(`input[value="${value}"]`).prop('checked', false);
       if($('.selected-categories .cats').is(':empty')) {
         $('.selected-categories').removeClass('active');

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -105,7 +105,7 @@ $(document).ready(() => {
       else {
         console.log("You can't add more categries!");
         if (!$('.cat-warning').length){
-          $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>");
+          $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>")
         }
       }
     } else {

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -104,7 +104,7 @@ $(document).ready(() => {
       }
       else {
         console.log("You can't add more categries!");
-        $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>")
+        $('.all-categories').prepend("<h3 class='cat-warning'>You can only select 3 categories.</h3>");
       }
     } else {
       // console.log('unchecked');

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -103,7 +103,7 @@ $(document).ready(() => {
         $('.selected-categories .cats').append(`<div class="selected-cat" data-cat="${value}"><span class="remove"></span>${label}</div>`);
       }
       else {
-        console.log("You can't add more categries!")
+        console.log("You can't add more categries!");
       }
     } else {
       // console.log('unchecked');

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -102,6 +102,9 @@ $(document).ready(() => {
       if($('.all-categories input:checkbox:checked').length < 4) {
         $('.selected-categories .cats').append(`<div class="selected-cat" data-cat="${value}"><span class="remove"></span>${label}</div>`);
       }
+      else {
+        console.log("You can't add more categries!")
+      }
     } else {
       // console.log('unchecked');
       $(`.selected-categories .cats .selected-cat[data-cat='${value}']`).remove();

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -119,6 +119,9 @@ $(document).ready(() => {
       var value = $(this).parent().attr('data-cat');
       // console.log(value);
       $(this).parent().remove();
+      if ($('.cat-warning').length){
+        $('.cat-warning').remove();
+      };
       $(`input[value="${value}"]`).prop('checked', false);
       if($('.selected-categories .cats').is(':empty')) {
         $('.selected-categories').removeClass('active');


### PR DESCRIPTION
Hi Rory,

I tried to be too smart for my own good and use a tooltip to inform the user that they could only select three categories one the max was reached as per https://github.com/Mike-Heneghan/ALISS/issues/48. After styling it I realised I couldn't dynamically assign the tooltip to the checkboxes. Instead, I've implemented a far simpler version where a `<h3>` appears when the user tries to select a fourth category which is hidden when a category is removed as seen https://drive.google.com/file/d/1_Gdg6iyppBXxh_sYesAvMoD1KsjVTWKz/view?usp=sharing It's far less sophisticated although I think it's clear and still an improvement?

When you get the chance please check it out and we can discuss it.

Cheers,

Mike 