### PR TITLE
Enhance/place name api

### DIFF
--- a/aliss/api/serializers.py
+++ b/aliss/api/serializers.py
@@ -168,3 +168,6 @@ Need to add a serializer for the locations data set.
 class PostcodeLocationSerializer(serializers.Serializer):
     place_name = serializers.CharField()
     postcode = serializers.CharField()
+
+class PostcodeLocationSearchSerializer(serializers.Serializer):
+    q = serializers.CharField(required=False)

--- a/aliss/api/serializers.py
+++ b/aliss/api/serializers.py
@@ -159,3 +159,12 @@ class v4CategorySerializer(serializers.Serializer):
     name = serializers.CharField()
     slug = serializers.SlugField()
     sub_categories = RecursiveField(many=True, source='children')
+
+
+'''
+Need to add a serializer for the locations data set.
+'''
+
+class PostcodeLocationSerializer(serializers.Serializer):
+    place_name = serializers.CharField()
+    postcode = serializers.CharField()

--- a/aliss/api/urls.py
+++ b/aliss/api/urls.py
@@ -14,5 +14,5 @@ urlpatterns = [
     url(r'^v4/organisations/(?P<slug>[0-9A-Za-z\-]+)/$', v4.OrganisationDetailView.as_view()),
     url('v4/services/(?P<pk>[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})/', v4.ServiceDetailView.as_view()),
     url(r'^v4/services/(?P<slug>[0-9A-Za-z\-]+)/$',  v4.ServiceDetailView.as_view()),
-    url(r'^v4/postcode-locations/$', v4.PostcodeLocationData.as_view()),
+    url(r'^v4/postcode-locations/((?P<q>.+)/)?$', v4.PostcodeLocationData.as_view()),
 ]

--- a/aliss/api/urls.py
+++ b/aliss/api/urls.py
@@ -14,5 +14,5 @@ urlpatterns = [
     url(r'^v4/organisations/(?P<slug>[0-9A-Za-z\-]+)/$', v4.OrganisationDetailView.as_view()),
     url('v4/services/(?P<pk>[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})/', v4.ServiceDetailView.as_view()),
     url(r'^v4/services/(?P<slug>[0-9A-Za-z\-]+)/$',  v4.ServiceDetailView.as_view()),
-    url(r'^v4/postcode-locations/((?P<q>[0-9A-Fa-f]+)/)?$', v4.PostcodeLocationData.as_view()),
+    url(r'^v4/postcode-locations/(?P<q>.+)', v4.PostcodeLocationData.as_view()),
 ]

--- a/aliss/api/urls.py
+++ b/aliss/api/urls.py
@@ -14,5 +14,5 @@ urlpatterns = [
     url(r'^v4/organisations/(?P<slug>[0-9A-Za-z\-]+)/$', v4.OrganisationDetailView.as_view()),
     url('v4/services/(?P<pk>[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})/', v4.ServiceDetailView.as_view()),
     url(r'^v4/services/(?P<slug>[0-9A-Za-z\-]+)/$',  v4.ServiceDetailView.as_view()),
-    url(r'^v4/postcode-locations/((?P<q>.+)/)?$', v4.PostcodeLocationData.as_view()),
+    url(r'^v4/postcode-locations/((?P<q>[0-9A-Fa-f]+)/)?$', v4.PostcodeLocationData.as_view()),
 ]

--- a/aliss/api/urls.py
+++ b/aliss/api/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     url(r'^v4/organisations/(?P<slug>[0-9A-Za-z\-]+)/$', v4.OrganisationDetailView.as_view()),
     url('v4/services/(?P<pk>[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})/', v4.ServiceDetailView.as_view()),
     url(r'^v4/services/(?P<slug>[0-9A-Za-z\-]+)/$',  v4.ServiceDetailView.as_view()),
+    url(r'^v4/postcode-locations/$', v4.PostcodeLocationData.as_view()),
 ]

--- a/aliss/api/urls.py
+++ b/aliss/api/urls.py
@@ -14,5 +14,5 @@ urlpatterns = [
     url(r'^v4/organisations/(?P<slug>[0-9A-Za-z\-]+)/$', v4.OrganisationDetailView.as_view()),
     url('v4/services/(?P<pk>[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})/', v4.ServiceDetailView.as_view()),
     url(r'^v4/services/(?P<slug>[0-9A-Za-z\-]+)/$',  v4.ServiceDetailView.as_view()),
-    url(r'^v4/postcode-locations/(?P<q>.+)', v4.PostcodeLocationData.as_view()),
+    url(r'^v4/postcode-locations/$', v4.PostcodeLocationData.as_view()),
 ]

--- a/aliss/api/v4_views.py
+++ b/aliss/api/v4_views.py
@@ -125,6 +125,8 @@ class PostcodeLocationData(generics.ListAPIView):
 
     def filter_queryset(self, queryset):
         query = self.input_data.get('q', None)
-        if query:
+        if len(query) > 2:
             queryset = queryset.filter(place_name__istartswith = query)
-        return queryset
+            return queryset
+        else:
+            return None

--- a/aliss/api/v4_views.py
+++ b/aliss/api/v4_views.py
@@ -125,7 +125,7 @@ class PostcodeLocationData(generics.ListAPIView):
 
     def filter_queryset(self, queryset):
         query = self.input_data.get('q', None)
-        if len(query) > 2:
+        if query and len(query) > 2:
             queryset = queryset.filter(place_name__istartswith = query)
             return queryset
         else:

--- a/aliss/api/v4_views.py
+++ b/aliss/api/v4_views.py
@@ -112,8 +112,11 @@ Need to create a new api endpoint which will be queried with three characters wh
 class PostcodeLocationData(generics.ListAPIView):
     def get(self, request, q=None):
         queryset = Postcode.objects.exclude(place_name=None)
-        if q != None:
-            queryset = queryset.filter(place_name__startswith=q)
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.error(str(q))
+        if q == None:
+            queryset = queryset.filter(place_name__startswith="Por")
         serializer = PostcodeLocationSerializer(queryset, many=True)
         data = OrderedDict()
         data['data'] = serializer.data

--- a/aliss/api/v4_views.py
+++ b/aliss/api/v4_views.py
@@ -111,12 +111,13 @@ Need to create a new api endpoint which will be queried with three characters wh
 
 class PostcodeLocationData(generics.ListAPIView):
     def get(self, request, q=None):
+
         queryset = Postcode.objects.exclude(place_name=None)
         import logging
         logger = logging.getLogger(__name__)
         logger.error(str(q))
-        if q == None:
-            queryset = queryset.filter(place_name__startswith="Por")
+        if q != None:
+            queryset = queryset.filter(place_name__startswith=q)
         serializer = PostcodeLocationSerializer(queryset, many=True)
         data = OrderedDict()
         data['data'] = serializer.data

--- a/aliss/api/v4_views.py
+++ b/aliss/api/v4_views.py
@@ -2,7 +2,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import generics
 from . import views as v3
-from aliss.models import Category, ServiceArea, Organisation, Service
+from aliss.models import Category, ServiceArea, Organisation, Service, Postcode
 from collections import OrderedDict
 from copy import deepcopy
 from django.shortcuts import get_object_or_404
@@ -13,7 +13,8 @@ from .serializers import (
     v4CategorySerializer,
     v4ServiceAreaSerializer,
     v4OrganisationDetailSerializer,
-    v4ServiceSerializer
+    v4ServiceSerializer,
+    PostcodeLocationSerializer
 )
 
 class APIv4():
@@ -101,4 +102,20 @@ class ServiceDetailView(v3.TrackUsageMixin, APIView):
         context = { 'request': request }
         data = OrderedDict({'meta': APIv4.META})
         data['data'] = v4ServiceSerializer(service, many=False, context=context).data
+        return Response(data)
+
+
+'''
+Need to create a new api endpoint which will be queried with three characters which will then return json holding matching postcodes. Look to categories for inspiration.
+'''
+
+class PostcodeLocationData(generics.ListAPIView):
+    def get_queryset(self):
+        return Postcode.objects.exclude(place_name=None)
+
+    def list(self, request):
+        queryset = self.get_queryset()
+        serializer = PostcodeLocationSerializer(queryset, many=True)
+        data = OrderedDict()
+        data['data'] = serializer.data
         return Response(data)

--- a/aliss/api/v4_views.py
+++ b/aliss/api/v4_views.py
@@ -110,11 +110,10 @@ Need to create a new api endpoint which will be queried with three characters wh
 '''
 
 class PostcodeLocationData(generics.ListAPIView):
-    def get_queryset(self):
-        return Postcode.objects.exclude(place_name=None)
-
-    def list(self, request):
-        queryset = self.get_queryset()
+    def get(self, request, q=None):
+        queryset = Postcode.objects.exclude(place_name=None)
+        if q != None:
+            queryset = queryset.filter(place_name__startswith=q)
         serializer = PostcodeLocationSerializer(queryset, many=True)
         data = OrderedDict()
         data['data'] = serializer.data

--- a/aliss/templates/homepage.html
+++ b/aliss/templates/homepage.html
@@ -71,29 +71,30 @@
     $(document).ready(function(){
       var options = {
 
-        /*url: function(phrase) {
-          return "http://api/locations/search/?q=" + phrase;
-        },*/
 
-        data: [
-          {"location_name": "Glasgow", "postcode": "G2 4AA"},
-          {"location_name": "Edinburgh", "postcode": "EH2 4AD"},
-          {"location_name": "Aberdeen", "postcode": "AB10 1FQ"},
-          {"location_name": "Dundee", "postcode": "DD1 1DA"},
-          {"location_name": "Paisley", "postcode": "PA1 2AF"},
-          {"location_name": "East Kilbride", "postcode": "G74 1NX"},
-          {"location_name": "Inverness", "postcode": "IV1 1HD"},
-          {"location_name": "Livingston", "postcode": "EH54 6TP"},
-          {"location_name": "Hamilton", "postcode": "ML3 9AY"},
-          {"location_name": "Cumbernauld", "postcode": "G70 6AD"},
-          {"location_name": "Dunfermline", "postcode": "KY12 7JA"},
-          {"location_name": "Kirkcaldy", "postcode": "KY1 1DL"},
-          {"location_name": "Ayr", "postcode": "KA7 2EL"},
-          {"location_name": "Perth", "postcode": "PH2 8PA"},
-          {"location_name": "Kilmarnock", "postcode": "KA1 1PA"},
-        ],
+        url: function(phrase) {
+          return "/api/v4/postcode-locations/?q=" + phrase;
+        },
 
-        getValue: "location_name",
+        // data: [
+        //   {"place_name": "Glasgow", "postcode": "G2 4AA"},
+        //   {"place_name": "Edinburgh", "postcode": "EH2 4AD"},
+        //   {"place_name": "Aberdeen", "postcode": "AB10 1FQ"},
+        //   {"place_name": "Dundee", "postcode": "DD1 1DA"},
+        //   {"place_name": "Paisley", "postcode": "PA1 2AF"},
+        //   {"place_name": "East Kilbride", "postcode": "G74 1NX"},
+        //   {"place_name": "Inverness", "postcode": "IV1 1HD"},
+        //   {"place_name": "Livingston", "postcode": "EH54 6TP"},
+        //   {"place_name": "Hamilton", "postcode": "ML3 9AY"},
+        //   {"place_name": "Cumbernauld", "postcode": "G70 6AD"},
+        //   {"place_name": "Dunfermline", "postcode": "KY12 7JA"},
+        //   {"place_name": "Kirkcaldy", "postcode": "KY1 1DL"},
+        //   {"place_name": "Ayr", "postcode": "KA7 2EL"},
+        //   {"place_name": "Perth", "postcode": "PH2 8PA"},
+        //   {"place_name": "Kilmarnock", "postcode": "KA1 1PA"},
+        // ],
+
+        getValue: "place_name",
 
         template: {
           type: "custom",

--- a/aliss/tests/api/test_v4_postcode_locations_view.py
+++ b/aliss/tests/api/test_v4_postcode_locations_view.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from django.test import Client
+from django.urls import reverse
+from aliss.tests.fixtures import Fixtures
+from aliss.models import *
+
+class v4PostcodeLocationDataViewTestCase(TestCase):
+
+    def setUp(self):
+      self.service = Fixtures.create()
+      self.client = Client()
+
+    def test_get(self):
+        response = self.client.get('/api/v4/postcode-locations/', { 'q': 'Gla' }, format="json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        # print(response.content)
+
+
+    def tearDown(self):
+        self.service.delete()
+        for organisation in Organisation.objects.filter(name="TestOrg"):
+            organisation.delete()

--- a/aliss/urls/account.py
+++ b/aliss/urls/account.py
@@ -159,7 +159,7 @@ urlpatterns = [
         AccountDetailView.as_view(),
         name='account_detail'
     ),
-    url(r'^user/(?P<pk>[0-9A-Za-z\-]+)/editor/$',
+    url(r'^user/(?P<pk>.+)/editor/$',
         AccountIsEditor.as_view(),
         name='account_is_editor'
     )


### PR DESCRIPTION
## Description
- The autocomplete feature for placenames was implemented with a small data set of hard-coded locations in Scotland based on populations sizes. 

- To expand this feature it was necessary to create an API endpoint of placenames and associated postcodes. 

- @digitalWestie created the data set and updated the Postcodes DB to add the new column of `place_names`.

- After creating the API endpoint I updated the autocomplete JS to query it for the postcode and locations data. 

## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/65
- https://github.com/Mike-Heneghan/ALISS/issues/59

## Relevant Screenshots 
When inputting two characters the autocomplete doesn't appear. 
<img width="655" alt="Screenshot 2019-04-22 at 09 39 37" src="https://user-images.githubusercontent.com/36415632/56492093-9794ab00-64e2-11e9-9ad8-61d01586fee8.png">

On typing the third character the suggestions appear from the postcode-locations API:
<img width="633" alt="Screenshot 2019-04-22 at 09 39 45" src="https://user-images.githubusercontent.com/36415632/56492099-9f544f80-64e2-11e9-91a7-275e5ab099c2.png">

## Testing
- Using some of the other API tests as a template created one for the postcode locations.
- Successfully check then the response was JSON with status code 200.
- Couldn't successfully show that the place names were returned as expected in the automates test. 

## Follow Up
- [ ] Trial the feature with the team to discuss the expanded locations. 
- [ ]  Write robust tests for the postcode-locations API.
- [ ] Ensure the API isn't exposed. 