### PR TITLE
bug/status-500-login

### DIFF
--- a/aliss/views/account.py
+++ b/aliss/views/account.py
@@ -36,16 +36,19 @@ import logging
 
 def login_view(request, *args, **kwargs):
     if request.method == 'POST':
-        username = request.POST.get('username')
-        user = ALISSUser.objects.get(email=username)
-        if not request.POST.get('remember_me', None):
-            request.session.set_expiry(0)
-        logger = logging.getLogger(__name__)
-        referer = request.META.get('HTTP_REFERER', '/')
-        if 'next' not in referer:
-            if len(user.services_to_review_ids()) > 0:
-                auth_views.login(request, *args, **kwargs)
-                return HttpResponseRedirect(reverse('account_my_reviews'))
+        try:
+            username = request.POST.get('username')
+            user = ALISSUser.objects.get(email=username)
+            if not request.POST.get('remember_me', None):
+                request.session.set_expiry(0)
+            referer = request.META.get('HTTP_REFERER', '/')
+            if 'next' not in referer:
+                if len(user.services_to_review_ids()) > 0:
+                    auth_views.login(request, *args, **kwargs)
+                    return HttpResponseRedirect(reverse('account_my_reviews'))
+            return auth_views.login(request, *args, **kwargs)
+        except ALISSUser.DoesNotExist:
+            return auth_views.login(request, *args, **kwargs)
     return auth_views.login(request, *args, **kwargs)
 
 class AccountSignupView(CreateView):


### PR DESCRIPTION
## Description
- The content-review feature check queries the DB for the user based on the username. 

- If an invalid username is queried rather than the appropriate error guidance rendering over the login form a 500 error is returned `ALISSUser` not found.

- Updated the login view with a `try: except:` block to handle the case that the ALISSUser doesn't exist.

- Tried to test but the Unit TestCase has a minimal response object on login so couldn't figure out how to make a valid assertion. 


## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/70

## Relevant Screenshots 
<img width="445" alt="Screenshot 2019-07-03 at 12 38 22" src="https://user-images.githubusercontent.com/36415632/60588712-8fcd6e80-9d8f-11e9-83dd-7da0c2aa78ab.png">


## Testing
- Struggling to test the response from `client.login` as the response is a boolean and doesn't seem to have more complex attributes. 

## Follow Up
- [ ] Discuss more rigorous testing or a workaround. 