### PR TITLE
Enhance/results distance values

### DIFF
--- a/aliss/search.py
+++ b/aliss/search.py
@@ -393,7 +393,7 @@ def filter_by_created_on(queryset, comparison_date):
     return queryset
 
 
-def positions_dict(queryset):
+def positions_dict(queryset, distance_sort_boolean):
     results = queryset.count()
     sorted_hits = queryset[0:results].execute()
     positions = {}
@@ -401,50 +401,62 @@ def positions_dict(queryset):
     while i < results:
         positions[sorted_hits[i].id] = None
         if "sort" not in sorted_hits[i].meta:
-            positions[sorted_hits[i].id] = i
+            positions[sorted_hits[i].id] = {"place":i, "score": None}
         elif type(sorted_hits[i].meta.sort[0]) == float:
-            positions[sorted_hits[i].id] = i
+            if distance_sort_boolean:
+                positions[sorted_hits[i].id] = {"place":i, "score":sorted_hits[i].meta.sort[0]}
+            else:
+                positions[sorted_hits[i].id] = {"place":i, "score": None}
+
+        else:
+            positions[sorted_hits[i].id] = {"place":i, "score": None}
         i=i+1
     return positions
 
 
 def postcode_order(queryset, postcode):
     postcode_sqs = sort_by_postcode(queryset, postcode)
-    positions = positions_dict(postcode_sqs)
+    positions = positions_dict(postcode_sqs, True)
     return {
         "ids": list(positions.keys()),
-        "order": Case(*[When(id=key, then=positions[key]) for key in positions])
+        "order": Case(*[When(id=key, then=positions[key]["place"]) for key in positions]),
+        "distance_scores": generate_distance_scores(positions)
     }
-
 
 def keyword_order(queryset):
-    positions = positions_dict(queryset)
+    positions = positions_dict(queryset, False)
     return {
         "ids": list(positions.keys()),
-        "order": Case(*[When(id=key, then=positions[key]) for key in positions])
+        "order": Case(*[When(id=key, then=positions[key]["place"]) for key in positions]),
+        "distance_scores": generate_distance_scores(positions)
     }
 
+def generate_distance_scores(positions):
+    distance_scores = {}
+    for key in positions:
+        distance_scores[key] = positions[key]["score"]
+    return distance_scores
 
 def combined_order(filtered_queryset, postcode):
     postcode_sqs = sort_by_postcode(filtered_queryset, postcode)
-
-    distance_sorted = positions_dict(postcode_sqs)
-    keyword_sorted  = positions_dict(filtered_queryset)
-
+    distance_sorted = positions_dict(postcode_sqs, True)
+    keyword_sorted  = positions_dict(filtered_queryset, False)
     positions = { "distance": distance_sorted, "keyword": keyword_sorted }
     combined = {}
 
     for key in positions["distance"]:
-      if positions["distance"][key] == None:
-        combined[key] = float(positions["keyword"][key])
+      if positions["distance"][key]["place"] == None:
+        combined[key]["place"] = float(positions["keyword"][key]["place"])
       else:
-        total = positions["distance"][key] + positions["keyword"][key]
-        combined[key] = (total / 2.0)
-
+        total = positions["distance"][key]["place"] + positions["keyword"][key]["place"]
+        distance = positions["distance"][key]["score"]
+        combined[key] = {"place":(total/2.0), "score":distance}
     return {
         "ids": list(combined.keys()),
-        "order": Case(*[When(id=key, then=combined[key]) for key in combined])
+        "order": Case(*[When(id=key, then=combined[key]["place"]) for key in combined]),
+        "distance_scores": generate_distance_scores(combined)
     }
+
 
 def filter_by_claimed_status(queryset, claimed_status):
     queryset = queryset.query({

--- a/aliss/templates/search/partials/results-content.html
+++ b/aliss/templates/search/partials/results-content.html
@@ -174,6 +174,10 @@
 
             {% include 'service/partials/locations.html' with locations=result.locations.all %}
 
+            {% if distance_scores|get_score:result.id%}
+              <p>Distance:{{distance_scores|get_score:result.id}}(km)</p>
+            {% endif %}
+
             <ul class="contact-info">
               {% if result.phone %}
                 <li>

--- a/aliss/templates/search/partials/results-content.html
+++ b/aliss/templates/search/partials/results-content.html
@@ -174,7 +174,7 @@
 
             {% include 'service/partials/locations.html' with locations=result.locations.all %}
 
-            {% if distance_scores|get_score:result.id%}
+            {% if distance_scores|get_score:result.id %}
               <p>Distance: {{distance_scores|get_score:result.id}}(km)</p>
             {% endif %}
 

--- a/aliss/templates/search/partials/results-content.html
+++ b/aliss/templates/search/partials/results-content.html
@@ -175,7 +175,7 @@
             {% include 'service/partials/locations.html' with locations=result.locations.all %}
 
             {% if distance_scores|get_score:result.id%}
-              <p>Distance:{{distance_scores|get_score:result.id}}(km)</p>
+              <p>Distance: {{distance_scores|get_score:result.id}}(km)</p>
             {% endif %}
 
             <ul class="contact-info">

--- a/aliss/templatetags/aliss.py
+++ b/aliss/templatetags/aliss.py
@@ -122,11 +122,15 @@ def get_item(dictionary, key):
 
 @register.filter
 def get_score(dictionary, key):
-    distance_meter = dictionary.get(str(key))
-    if type(distance_meter) == float:
-        distance_km = (distance_meter / 1000.0)
-        rounded_km = round(distance_km, 2)
-        return rounded_km
+    try:
+        distance_meter = dictionary.get(str(key))
+        if type(distance_meter) == float:
+            distance_km = (distance_meter / 1000.0)
+            rounded_km = round(distance_km, 2)
+            return rounded_km
+    except:
+        return None
+
 
 @register.filter
 def format_time_string(value):

--- a/aliss/templatetags/aliss.py
+++ b/aliss/templatetags/aliss.py
@@ -120,6 +120,13 @@ def get_icon(category):
 def get_item(dictionary, key):
     return dictionary.get(key)
 
+@register.filter
+def get_score(dictionary, key):
+    distance_meter = dictionary.get(str(key))
+    if type(distance_meter) == float:
+        distance_km = (distance_meter / 1000.0)
+        rounded_km = round(distance_km, 2)
+        return rounded_km
 
 @register.filter
 def format_time_string(value):

--- a/aliss/tests/views/test_search_view.py
+++ b/aliss/tests/views/test_search_view.py
@@ -13,6 +13,13 @@ class SearchViewTestCase(TestCase):
         s = Service.objects.create(name="My First Service", description="A handy service", organisation=o, created_by=t, updated_by=u)
         s.service_areas.add(ServiceArea.objects.get(name="Glasgow City", type=2))
 
+        self.s2 = Service.objects.create(name="My Testing Service", description="A testing service", organisation=o, created_by=t, updated_by=u)
+
+        l = Fixtures.create_location(o)
+        self.s2.locations.add(l)
+        self.s2.service_areas.add(ServiceArea.objects.get(name="Glasgow City", type=2))
+        self.s2.save()
+
         brechin_postcode = Postcode.objects.create(
             postcode="DD9 6AD", postcode_district="DD9",  postcode_sector="DD3 8",
             latitude="56.73313937", longitude="-2.65779541",
@@ -82,6 +89,7 @@ class SearchViewTestCase(TestCase):
     def test_get(self):
         response = self.client.get('/search/?postcode=G2+4AA')
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "My Testing Service")
         self.assertContains(response, 'Help and support in <span class="postcode">G2 4AA</span>')
 
     def test_invalid_postcode(self):
@@ -142,6 +150,7 @@ class SearchViewTestCase(TestCase):
         self.assertContains(response, "New organisations search")
 
     def test_no_results_no_new_organisation_search_button_without_keyword(self):
+        self.s2.delete()
         self.multi_location_service.delete()
         response = self.client.get('/search/?postcode=G2+4AA&q=')
         self.assertEqual(response.status_code, 200)
@@ -183,6 +192,19 @@ class SearchViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<span class=\"first-location\">")
         self.assertContains(response, "<a class=\"more-link\" tabindex=\"0\">More Locations</a>")
+
+    def test_10km_radius_filter_returns_distance_score(self):
+        response = self.client.get('/search/?postcode=G2+9ZZ&radius=10000')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "G2 9ZZ")
+        self.assertContains(response, "My Testing Service")
+        self.assertContains(response, "Distance: 1.4(km)")
+
+    def test_1km_radius_filter_returns_distance_score(self):
+        response = self.client.get('/search/?postcode=G2+9ZZ&radius=1000')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "My Testing Service")
+        self.assertNotContains(response, "Distance: 1.4(km)")
 
     def tearDown(self):
         Fixtures.organisation_teardown()

--- a/aliss/views/search.py
+++ b/aliss/views/search.py
@@ -35,6 +35,7 @@ class SearchView(MultipleObjectMixin, TemplateView):
             context['service_area'] = service_area.name
         context['category'] = self.category
         context['expanded_radius'] = self.radius * 2
+        context['distance_scores'] = self.distance_scores
         return context
 
     def get(self, request, *args, **kwargs):
@@ -88,6 +89,7 @@ class SearchView(MultipleObjectMixin, TemplateView):
             results = combined_order(queryset, self.postcode)
         else:
             results = postcode_order(queryset, self.postcode)
+        self.distance_scores = self.check_distance_within_radius(results["distance_scores"], self.radius)
         return Service.objects.filter(id__in=results["ids"]).order_by(results["order"])
 
     def assign_legacy_postcode(self, location, legacy_locations_dict):
@@ -131,6 +133,11 @@ class SearchView(MultipleObjectMixin, TemplateView):
                 result["name"] = str(legacy_location_name)
         return result
 
+    def check_distance_within_radius(self, distance_scores, radius):
+        for key in distance_scores.keys():
+            if distance_scores[key] != None and distance_scores[key] > radius:
+                distance_scores[key] = None
+        return distance_scores
 
 class SearchShareView(View):
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
## Description
- When Elasticsearch is used to sort service results based on a postcode search the distance between the searched postcodes and service locations are calculated in metres and returned in ascending order. 

- This distance data can be captured and returned as a dictionary of service ids and distances. 

- This can then be returned in the view on context["distance_scores"] and displayed in the template.

- When searching for services the radius for the search is used to filter the results. The Elasticscore search scores take into account "service_areas" and hence when a search is down with a 1km radius, a service with a location which is 1.5km can appear due to its service area being Scotland.

- This can lead to confusion as the distance appears to be out with the range. 

- To address this I created an additional method which compares the distance score to the radius being searched and omits results which are outwith. 

## Related Issue/Issues

https://github.com/Mike-Heneghan/ALISS/issues/59
https://github.com/Mike-Heneghan/ALISS/issues/63
https://github.com/Mike-Heneghan/ALISS/issues/67

## Relevant Screenshots 

<img width="1200" alt="Screenshot 2019-04-12 at 10 23 07" src="https://user-images.githubusercontent.com/36415632/56029548-8d202780-5d12-11e9-9539-7bacf3fe4b58.png">

<img width="1249" alt="Screenshot 2019-04-12 at 10 23 21" src="https://user-images.githubusercontent.com/36415632/56029556-901b1800-5d12-11e9-8bed-70861dfe9d87.png">

## Testing
- Added a test to check a distance score is returned when a service is in an associated service area but doesn't show the distance value if it's out with the search radius.

- Changed to the way the distance scores are returned will affect the tests as they rely on the current "Distance: 1.4(km)" style. 
## Follow Up

- [ ] Feedback on changes.
- [ ] Improve the distance value styling.
- [ ] Review the distance value language.