### PR TITLE
Bug/map centering single feature

### DIFF
--- a/aliss/search.py
+++ b/aliss/search.py
@@ -564,7 +564,7 @@ def return_feature(service_area_type, service_area_code):
         return_feature = []
         for feature in js['features']:
             if feature['properties'][dataset[str(service_area_type)]["code_key"]] == service_area_code:
-                return_feature = json.dumps(feature)
+                return_feature = feature
         return return_feature
     else:
         return None

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -641,7 +641,7 @@ $(document).ready(() => {
         }
         result.forEach(function(feature){
           if (feature.length != 0){
-            var geo_feature = JSON.parse(feature);
+            var geo_feature = feature;
             var geoJSON = L.geoJson(geo_feature).addTo(mymap);
             if (singleArea){
               if (geo_feature.properties.long){

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -646,7 +646,7 @@ $(document).ready(() => {
             if (singleArea){
               if (geo_feature.properties.long){
                 var long = (geo_feature.properties.long);
-                var lat = (geo_feature.properties.long);
+                var lat = (geo_feature.properties.lat);
                 mymap.setView([lat, long], 6);
               }
             }


### PR DESCRIPTION
## Description
- When a service has a single service area the map centres on the feature if the lat long are available. 

- Accidentally set the long as the lat causing the map to centre in unrelated areas. 

- Also, the API was serving geodata as an escaped string.

- Updated to serve JSON improving performance.


## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/84

## Follow Up
- [ ] Have another look at getting the test to work for geospatial data endpoint.
