### PR TITLE
enhance/map-centre-single-location

### DIFF
--- a/aliss/templates/service/detail.html
+++ b/aliss/templates/service/detail.html
@@ -369,14 +369,17 @@
         setMapSize(targetId);
         var mymap = renderMap(targetId);
 
+        var no_geo_features = true;
+
         var serviceId =  "{{service.id}}";
         if ("{{service.service_areas.all.0|safe}}" != ""){
           renderFeatures(mymap, serviceId);
+          no_geo_features = false;
         }
 
         var locations = {{location_lat_longs|safe}};
         if (!$.isEmptyObject(locations)){
-          addLocations(mymap, locations);
+          addLocations(mymap, locations, no_geo_features);
         }
 
       });

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -664,11 +664,19 @@ $(document).ready(() => {
     });
   };
 
-  window.addLocations = function(mymap, locations){
+  window.addLocations = function(mymap, locations, no_geo_features = true){
+    var singleLocation = false;
+    if (Object.keys(locations).length == 1){
+      singleLocation = true;
+    }
     $.each(locations, function(key, value){
       L.marker(value).addTo(mymap)
       .bindPopup(`<a href=https://maps.google.com/?q=${value[0]},${value[1]} target="_blank">${key}</a>`);
+      if (singleLocation && no_geo_features){
+          mymap.setView(value, 6);
+      }
     });
+
   };
 
   svg4everybody();


### PR DESCRIPTION
## Description
- Currently, if there is a single location the map maintains the default centring and zoom.

- Updated the JS to check for the number of service area geo_features. If there are none and there is only one location the map centres and zoom to that location. 

- If there is only one geo_feature the map centres and zooms to the geo_feature regardless of the number of locations. 

-  This behaviour prefers adjusting the map to better inform the user of service areas as it was the primary focus of adding maps to the detail page. 

## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/93

## Relevant Screenshots 

<img width="686" alt="Screenshot 2019-07-30 at 15 50 43" src="https://user-images.githubusercontent.com/36415632/62139797-d7d5a780-b2e1-11e9-83cd-ab26d1ab32cb.png">

## Testing
- As a JS feature only visually tested. 

## Follow Up
- [ ] May need to update static files. 
- [ ] Feedback on the feature. 
