### PR TITLE
Enhance/iframe service detail map

### DIFF
--- a/aliss/templates/service/embedded_map.html
+++ b/aliss/templates/service/embedded_map.html
@@ -24,8 +24,7 @@
     $(document).ready(function(){
 
       var targetId = 'mapid'
-
-      setMapSize(targetId);
+      
       var mymap = renderMap(targetId);
 
       var serviceId =  "{{service.id}}";

--- a/aliss/templates/service/embedded_map.html
+++ b/aliss/templates/service/embedded_map.html
@@ -1,16 +1,16 @@
-{% extends "base.html" %}
 {% load aliss %}
-{% load analytics %}
+{% load static %}
 
-<main class="main" role="main">
-  <article id="content" class="service">
-    <div id='mapid'></div>
-  </article>
-</main>
+  <main class="main" role="main">
+    <article id="content" class="service">
+      <div id="mapid" style="height: 500px; width: 500px;"></div>
+    </article>
+  </main>
 
 {% block before_body_close %}
 
-{% if service %}
+  <script type="text/javascript" src="{% static 'js/scripts.js' %}"></script>
+
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
   integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
   crossorigin=""/>
@@ -40,6 +40,5 @@
 
     });
   </script>
-{% endif %}
 
 {% endblock %}

--- a/aliss/templates/service/embedded_map.html
+++ b/aliss/templates/service/embedded_map.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% load aliss %}
+{% load analytics %}
+
+<main class="main" role="main">
+  <article id="content" class="service">
+    <div id='mapid'></div>
+  </article>
+</main>
+
+{% block before_body_close %}
+
+{% if service %}
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
+  integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
+  crossorigin=""/>
+
+  <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
+  integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
+  crossorigin="">
+  </script>
+
+  <script type="text/javascript">
+    $(document).ready(function(){
+
+      var targetId = 'mapid'
+
+      setMapSize(targetId);
+      var mymap = renderMap(targetId);
+
+      var serviceId =  "{{service.id}}";
+      if ("{{service.service_areas.all.0|safe}}" != ""){
+        renderFeatures(mymap, serviceId);
+      }
+
+      var locations = {{location_lat_longs|safe}};
+      if (!$.isEmptyObject(locations)){
+        addLocations(mymap, locations);
+      }
+
+    });
+  </script>
+{% endif %}
+
+{% endblock %}

--- a/aliss/tests/views/test_service_view.py
+++ b/aliss/tests/views/test_service_view.py
@@ -205,6 +205,13 @@ class ServiceViewTestCase(TestCase):
         context_lat_longs_dict = response.context['location_lat_longs']
         self.assertEqual(comparison_lat_long_dict, context_lat_longs_dict)
 
+    def test_service_detail_slug_embedded_map(self):
+        response = self.client.get(reverse('service_detail_slug_map', kwargs={'slug':self.service.slug}))
+        self.assertEqual(response.status_code, 200)
+
+    def test_service_detail_pk_embedded_map(self):
+        response = self.client.get(reverse('service_detail_map', kwargs={'pk':self.service.pk}))
+        self.assertEqual(response.status_code, 200)
 
     def tearDown(self):
         Fixtures.organisation_teardown()

--- a/aliss/urls/service.py
+++ b/aliss/urls/service.py
@@ -3,6 +3,7 @@ from django.views.generic import TemplateView
 
 from aliss.views import (
     ServiceUpdateView,
+    ServiceDetailEmbeddedMapView,
     ServiceDetailView,
     ServiceDeleteView,
     ServiceReportProblemView,
@@ -49,6 +50,14 @@ urlpatterns = [
     url(r'^(?P<pk>[0-9A-Za-z\-]+)/report-problem/$',
         ServiceReportProblemView.as_view(),
         name='service_report_problem'
+    ),
+    url("(?P<pk>[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})/embedded-map",
+        ServiceDetailEmbeddedMapView.as_view(),
+        name='service_detail_map'
+    ),
+    url(r'^(?P<slug>[0-9A-Za-z\-]+)/embedded-map',
+        ServiceDetailEmbeddedMapView.as_view(),
+        name='service_detail_slug_map'
     ),
     url("(?P<pk>[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})",
         ServiceDetailView.as_view(),

--- a/aliss/views/__init__.py
+++ b/aliss/views/__init__.py
@@ -37,6 +37,7 @@ from .location import (
 from .service import (
     ServiceCreateView,
     ServiceUpdateView,
+    ServiceDetailEmbeddedMapView,
     ServiceDetailView,
     ServiceDeleteView,
     ServiceReportProblemView,

--- a/aliss/views/service.py
+++ b/aliss/views/service.py
@@ -151,9 +151,7 @@ class ServiceDetailEmbeddedMapView(UserPassesTestMixin, DetailView):
         return (service.is_published() or service.is_edited_by(user))
 
     def get_context_data(self, **kwargs):
-        context = super(ServiceDetailView, self).get_context_data(**kwargs)
-        if self.request.user.is_authenticated():
-            context['recommended_service_lists'] = RecommendedServiceList.objects.filter(user=self.request.user)
+        context = super(ServiceDetailEmbeddedMapView, self).get_context_data(**kwargs)
         locations = self.object.locations.all()
         lat_longs = {}
         for location in locations:

--- a/aliss/views/service.py
+++ b/aliss/views/service.py
@@ -141,6 +141,26 @@ class ServiceDetailView(UserPassesTestMixin, DetailView):
         context['location_lat_longs'] = lat_longs
         return context
 
+class ServiceDetailEmbeddedMapView(UserPassesTestMixin, DetailView):
+    model = Service
+    template_name = 'service/embedded_map.html'
+    query_pk_and_slug = True
+
+    def test_func(self, user):
+        service = self.get_object()
+        return (service.is_published() or service.is_edited_by(user))
+
+    def get_context_data(self, **kwargs):
+        context = super(ServiceDetailView, self).get_context_data(**kwargs)
+        if self.request.user.is_authenticated():
+            context['recommended_service_lists'] = RecommendedServiceList.objects.filter(user=self.request.user)
+        locations = self.object.locations.all()
+        lat_longs = {}
+        for location in locations:
+            lat_longs[location.street_address] = [location.latitude, location.longitude]
+        context['location_lat_longs'] = lat_longs
+        return context
+
 
 class ServiceDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
     model = Service


### PR DESCRIPTION
## Description
-As an incentive for users to add their service data and keep it up to date, it was thought that the service detail map could be made available for users on their own website. 

- Created a page with the URL structure of 'services/service-id-or-slug/embedded-map' this returns a service detail map only and is intended to be used as the src for a user to add an iframe. 

- This would allow users to display a map of Scotland on their page populated with the appropriate service areas and location pins. 

- The feature could potentially be made more usable by adding a link in "Actions" for example which would save a dynamically created iFrame for the embedded map which could then be pasted into a users website HTML.

## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/90


## Relevant Screenshots 
<img width="712" alt="Screenshot 2019-08-07 at 11 02 47" src="https://user-images.githubusercontent.com/36415632/62620999-a331a380-b912-11e9-93b6-9f66427e7e28.png">


## Testing
- Added test to make sure status codes 200s are returned when an embedded map is requested. 
- Manually added an iFrame to a page to test. 

## Follow Up
- [ ] Discuss a means by which users can more easily add an iframe to their website. 
- [ ] Review and discuss a solution. 
