### PR TITLE
Enhance/service area explanation page

### DIFF
--- a/aliss/api/serializers.py
+++ b/aliss/api/serializers.py
@@ -172,3 +172,6 @@ class PostcodeLocationSearchSerializer(serializers.Serializer):
 
 class ServiceAreaSpatialSearchSerializer(serializers.Serializer):
     service_id = serializers.UUIDField(required=True)
+
+class ServiceAreaFullSpatialDataSetSearchSerializer(serializers.Serializer):
+    type = serializers.IntegerField()

--- a/aliss/api/urls.py
+++ b/aliss/api/urls.py
@@ -15,5 +15,6 @@ urlpatterns = [
     url('v4/services/(?P<pk>[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})/', v4.ServiceDetailView.as_view()),
     url(r'^v4/services/(?P<slug>[0-9A-Za-z\-]+)/$',  v4.ServiceDetailView.as_view()),
     url(r'^v4/postcode-locations/$', v4.PostcodeLocationData.as_view()),
+    url(r'^v4/service-area-spatial/full-set/$', v4.ServiceAreaFullSpatialDataSet.as_view()),
     url(r'^v4/service-area-spatial/$', v4.ServiceAreaSpatialData.as_view()),
 ]

--- a/aliss/api/v4_views.py
+++ b/aliss/api/v4_views.py
@@ -18,6 +18,7 @@ from .serializers import (
     PostcodeLocationSerializer,
     PostcodeLocationSearchSerializer,
     ServiceAreaSpatialSearchSerializer,
+    ServiceAreaFullSpatialDataSetSearchSerializer
 )
 
 class APIv4():
@@ -155,5 +156,15 @@ class ServiceAreaSpatialData(APIView):
                 returned.append(return_feature(type, code))
 
             service_area_features += returned
+        queryset = list(service_area_features)
+        return Response(queryset)
+
+class ServiceAreaFullSpatialDataSet(APIView):
+    def get(self, request, *args, **kwargs):
+        input_serializer = ServiceAreaFullSpatialDataSetSearchSerializer(data=request.query_params)
+        input_serializer.is_valid(raise_exception=True)
+        input_data = input_serializer.validated_data
+        area_type = input_data.get('type')
+        service_area_features = return_feature(area_type, 0, True)
         queryset = list(service_area_features)
         return Response(queryset)

--- a/aliss/api/v4_views.py
+++ b/aliss/api/v4_views.py
@@ -161,10 +161,19 @@ class ServiceAreaSpatialData(APIView):
 
 class ServiceAreaFullSpatialDataSet(APIView):
     def get(self, request, *args, **kwargs):
+
+        dataset_name_keys = {
+            0: "ctry17nm",
+            2: "lad18nm",
+            3: "HBName",
+            4: "HIAName",
+        }
+
         input_serializer = ServiceAreaFullSpatialDataSetSearchSerializer(data=request.query_params)
         input_serializer.is_valid(raise_exception=True)
         input_data = input_serializer.validated_data
         area_type = input_data.get('type')
         service_area_features = return_feature(area_type, 0, True)
         queryset = list(service_area_features)
-        return Response(queryset)
+        result = {"name_key": dataset_name_keys.get(area_type), "data": queryset}
+        return Response(result)

--- a/aliss/search.py
+++ b/aliss/search.py
@@ -534,7 +534,7 @@ def setup_data_set_doubles():
     return boundaries_data_mappings
 
 
-def return_feature(service_area_type, service_area_code):
+def return_feature(service_area_type, service_area_code=0, all_features=False):
     boundaries_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), './data/boundaries'))
     dataset = {
         "0": {
@@ -563,7 +563,9 @@ def return_feature(service_area_type, service_area_code):
             js = json.load(f)
         return_feature = []
         for feature in js['features']:
-            if feature['properties'][dataset[str(service_area_type)]["code_key"]] == service_area_code:
+            if all_features:
+                return_feature.append(feature)
+            elif feature['properties'][dataset[str(service_area_type)]["code_key"]] == service_area_code:
                 return_feature = feature
         return return_feature
     else:

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -3,18 +3,17 @@
 {% load analytics %}
 
 {% block container %}
-<main class="main" role="main">
-  <article id="content" class="service">
-    <div class="row">
-      <div class="columns content">
-        <div class="copy-container">
-          <h1>What is a service area?</h1>
-          <p>A service area is a boundary in which a service is available. For example,  although a service may have a physical location in the city centre, the service may be available in all of Glasgow. This could be possible through home visits or communication about the local area. ALthough, who decides what is and isn't within Glasgow?</p>
+  <main class="main" role="main">
+    <article id="content" class="service">
+      <div class="row">
+        <div class="columns content">
+          <div class="copy-container">
+            <h1>What is a service area?</h1>
+            <p>A service area is a boundary in which a service is available. For example,  although a service may have a physical location in the city centre, the service may be available in all of Glasgow. This could be possible through home visits or communication about the local area. ALthough, who decides what is and isn't within Glasgow?</p>
 
-          <p>Boundaries are set by different groups to help split the country into regions to ease management of concerns such as budget and responsibility. This can help to tailor the services provided to the needs of those who live in the boundary. A small charity may only have the resources and expertise to help individuals locally or be  ALISS supports several boundaries, such as:</p>
+            <p>Boundaries are set by different groups to help split the country into regions to ease management of concerns such as budget and responsibility. This can help to tailor the services provided to the needs of those who live in the boundary. A small charity may only have the resources and expertise to help individuals locally or be  ALISS supports several boundaries, such as:</p>
 
-          <!-- <div class="filter category"> -->
-            <label>Explore datasets</label>
+            <label>Explore datasets:</label>
             <ol id="dataset_options" class="radio-list-links"  style="list-style: none;">
               <li id="national" value=0>
                 <a>
@@ -49,41 +48,51 @@
                 </a>
               </li>
             </ol>
-          <!-- </div> -->
 
 
-          <div id="mapid"></div>
+            <div>
+              <div id="mapid" style="display:inline-block;">
+                <h3 id="loading" style="position: relative; top:40%; text-align: center;">Loading...</h3>
+              </div>
+            </div>
 
+          </div>
         </div>
       </div>
-    </div>
-  </article>
-</main>
+    </article>
+  </main>
 {% endblock %}
 
 {% block before_body_close %}
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
-    integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
-    crossorigin=""/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
+  integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
+  crossorigin=""/>
 
-    <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
-    integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
-    crossorigin="">
-    </script>
+  <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
+  integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
+  crossorigin="">
+  </script>
 
-    <script type="text/javascript">
-      $(document).ready(function(){
+  <script type="text/javascript">
+  $(document).ready(function(){
 
-        var targetId = 'mapid'
+    var targetId = 'mapid'
 
-        setMapSize(targetId);
-        var mymap = renderMap(targetId);
-        var test_arg = 'this';
+    setMapSize(targetId);
+    var mymap = renderMap(targetId);
+    var test_arg = 'this';
 
-        $('#dataset_options').children().each(function(){
-          $('#'+ this.id).click(function(){
-            $("li").removeClass("active")
-            $('#'+ this.id).addClass("active")
+    $('#dataset_options').children().each(function(){
+      $('#'+ this.id).click(function(){
+        $("li").removeClass("active")
+        $('#'+ this.id).addClass("active")
+        var features = $.ajax({
+          url: "/api/v4/service-area-spatial/full-set/?type=" + this.value,
+          beforeSend: function(){
+            $(".leaflet-pane").hide()
+          },
+          dataType : "json",
+          success: function(result){
             mymap.eachLayer(function(layer){
               if(layer._url && layer._url.includes('tile')){
               }
@@ -91,22 +100,18 @@
                 layer.remove()
               }
             })
-            var features = $.ajax({
-              url: "/api/v4/service-area-spatial/full-set/?type=" + this.value,
-              dataType : "json",
-              success: function(result){
-
-                name_key = result.name_key
-                result.data.forEach(function(feature){
-                  feature_name = feature.properties[`${name_key}`];
-                  var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
-                });
-              }
+            $(".leaflet-pane").show()
+            name_key = result.name_key
+            result.data.forEach(function(feature){
+              feature_name = feature.properties[`${name_key}`];
+              var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
             });
-          });
+          }
         });
-
       });
-    </script>
+    });
+
+  });
+  </script>
 
 {% endblock %}

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -13,7 +13,7 @@
 
           <p>Boundaries are set by different groups to help split the country into regions to ease management of concerns such as budget and responsibility. This can help to tailor the services provided to the needs of those who live in the boundary. A small charity may only have the resources and expertise to help individuals locally or be  ALISS supports several boundaries, such as:</p>
 
-          <ul>
+          <ul id="dataset_options">
             <li id="national" value=0><a href="#mapid">National</a></li>
             <li id="local_authority" value=2><a href="#mapid">Local Authority</a></li>
             <li id="nhs" value=3><a href="#mapid">NHS Healthboard</a></li>
@@ -49,88 +49,28 @@
 
         setMapSize(targetId);
         var mymap = renderMap(targetId);
+        var test_arg = 'this';
 
-        $('#national').click(mymap, function(){
-          mymap.eachLayer(function(layer){
-            if(layer._url && layer._url.includes('tile')){
-            }
-            else {
-              layer.remove()
-            }
-          })
-          var features = $.ajax({
-            url: "/api/v4/service-area-spatial/full-set/?type=" + $('#national').val(),
-            dataType : "json",
-            success: function(result){
-              name_key = result.name_key
-              result.data.forEach(function(feature){
-                feature_name = feature.properties[`${name_key}`];
-                var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
-              });
-            }
-          });
-        });
-
-        $('#local_authority').click(mymap, function(){
-          mymap.eachLayer(function(layer){
-            if(layer._url && layer._url.includes('tile')){
-            }
-            else {
-              layer.remove()
-            }
-          })
-          var features = $.ajax({
-            url: "/api/v4/service-area-spatial/full-set/?type=" + $('#local_authority').val(),
-            dataType : "json",
-            success: function(result){
-              name_key = result.name_key
-              result.data.forEach(function(feature){
-                feature_name = feature.properties[`${name_key}`];
-                var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
-              });
-            }
-          });
-        });
-
-        $('#nhs').click(mymap, function(){
-          mymap.eachLayer(function(layer){
-            if(layer._url && layer._url.includes('tile')){
-            }
-            else {
-              layer.remove()
-            }
-          })
-          var features = $.ajax({
-            url: "/api/v4/service-area-spatial/full-set/?type=" + $('#nhs').val(),
-            dataType : "json",
-            success: function(result){
-              name_key = result.name_key
-              result.data.forEach(function(feature){
-                feature_name = feature.properties[`${name_key}`];
-                var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
-              });
-            }
-          });
-        });
-
-        $('#hia').click(mymap, function(){
-          mymap.eachLayer(function(layer){
-            if(layer._url && layer._url.includes('tile')){
-            }
-            else {
-              layer.remove()
-            }
-          })
-          var features = $.ajax({
-            url: "/api/v4/service-area-spatial/full-set/?type=" + $('#hia').val(),
-            dataType : "json",
-            success: function(result){
-              name_key = result.name_key
-              result.data.forEach(function(feature){
-                feature_name = feature.properties[`${name_key}`];
-                var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
-              });
-            }
+        $('#dataset_options').children().each(function(){
+          $('#'+ this.id).click(function(){
+            mymap.eachLayer(function(layer){
+              if(layer._url && layer._url.includes('tile')){
+              }
+              else {
+                layer.remove()
+              }
+            })
+            var features = $.ajax({
+              url: "/api/v4/service-area-spatial/full-set/?type=" + this.value,
+              dataType : "json",
+              success: function(result){
+                name_key = result.name_key
+                result.data.forEach(function(feature){
+                  feature_name = feature.properties[`${name_key}`];
+                  var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
+                });
+              }
+            });
           });
         });
 

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -14,10 +14,10 @@
           <p>Boundaries are set by different groups to help split the country into regions to ease management of concerns such as budget and responsibility. This can help to tailor the services provided to the needs of those who live and work in the boundary. A small charity may only have the resources and expertise to help individuals locally or be  ALISS supports a numbers of boundaries such as:</p>
 
           <ul>
-            <li id="national"><a>National</a></li>
-            <li id="local_authority"><a>Local Authority</a></li>
-            <li id="nhs"><a>NHS Healthboard</a></li>
-            <li id="hia"><a>Integration Authority formerly HSCP</a></li>
+            <li id="national" value=0><a>National</a></li>
+            <li id="local_authority" value=2><a>Local Authority</a></li>
+            <li id="nhs" value=3><a>NHS Healthboard</a></li>
+            <li id="hia" value=4><a>Integration Authority formerly HSCP</a></li>
           </ul>
 
           <div id="mapid"></div>
@@ -50,8 +50,15 @@
         var mymap = renderMap(targetId);
 
         $('#national').click(mymap, function(){
+          mymap.eachLayer(function(layer){
+            if(layer._url && layer._url.includes('tile')){
+            }
+            else {
+              layer.remove()
+            }
+          })
           var features = $.ajax({
-            url: "/api/v4/service-area-spatial/full-set/?type=0",
+            url: "/api/v4/service-area-spatial/full-set/?type=" + $('#national').val(),
             dataType : "json",
             success: function(result){
               result.forEach(function(feature){
@@ -62,8 +69,15 @@
         });
 
         $('#local_authority').click(mymap, function(){
+          mymap.eachLayer(function(layer){
+            if(layer._url && layer._url.includes('tile')){
+            }
+            else {
+              layer.remove()
+            }
+          })
           var features = $.ajax({
-            url: "/api/v4/service-area-spatial/full-set/?type=2",
+            url: "/api/v4/service-area-spatial/full-set/?type=" + $('#local_authority').val(),
             dataType : "json",
             success: function(result){
               result.forEach(function(feature){
@@ -74,8 +88,15 @@
         });
 
         $('#nhs').click(mymap, function(){
+          mymap.eachLayer(function(layer){
+            if(layer._url && layer._url.includes('tile')){
+            }
+            else {
+              layer.remove()
+            }
+          })
           var features = $.ajax({
-            url: "/api/v4/service-area-spatial/full-set/?type=3",
+            url: "/api/v4/service-area-spatial/full-set/?type=" + $('#nhs').val(),
             dataType : "json",
             success: function(result){
               result.forEach(function(feature){
@@ -86,8 +107,15 @@
         });
 
         $('#hia').click(mymap, function(){
+          mymap.eachLayer(function(layer){
+            if(layer._url && layer._url.includes('tile')){
+            }
+            else {
+              layer.remove()
+            }
+          })
           var features = $.ajax({
-            url: "/api/v4/service-area-spatial/full-set/?type=4",
+            url: "/api/v4/service-area-spatial/full-set/?type=" + $('#hia').val(),
             dataType : "json",
             success: function(result){
               result.forEach(function(feature){

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -9,9 +9,9 @@
       <div class="columns content">
         <div class="copy-container">
           <h1>What is a service area?</h1>
-          <p>A service area is a boundary in which a service is available. For example a although a service may have a physical location in the city centre the service may be available in all of Glasgow. This could be through home visits or communication about the local area. ALthough, who decides what is and isn't within Glasgow?</p>
+          <p>A service area is a boundary in which a service is available. For example,  although a service may have a physical location in the city centre, the service may be available in all of Glasgow. This could be possible through home visits or communication about the local area. ALthough, who decides what is and isn't within Glasgow?</p>
 
-          <p>Boundaries are set by different groups to help split the country into regions to ease management of concerns such as budget and responsibility. This can help to tailor the services provided to the needs of those who live and work in the boundary. A small charity may only have the resources and expertise to help individuals locally or be  ALISS supports a numbers of boundaries such as:</p>
+          <p>Boundaries are set by different groups to help split the country into regions to ease management of concerns such as budget and responsibility. This can help to tailor the services provided to the needs of those who live in the boundary. A small charity may only have the resources and expertise to help individuals locally or be  ALISS supports several boundaries, such as:</p>
 
           <ul>
             <li id="national" value=0><a href="#mapid">National</a></li>

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% load aliss %}
+{% load analytics %}
+
+{% block container %}
+<main class="main" role="main">
+  <article id="content" class="service">
+    <div class="row">
+      <div class="columns content">
+        <div class="copy-container">
+          <h1>What is a Service Area?</h1>
+          <p></p>
+        </div>
+      </div>
+    </div>
+  </article>
+</main>
+
+{% endblock %}

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -49,12 +49,7 @@
               </li>
             </ol>
 
-
-            <div>
-              <div id="mapid" style="display:inline-block;">
-                <h3 id="loading" style="position: relative; top:40%; text-align: center;">Loading...</h3>
-              </div>
-            </div>
+            <div id="mapid"></div>
 
           </div>
         </div>
@@ -74,44 +69,19 @@
   </script>
 
   <script type="text/javascript">
-  $(document).ready(function(){
+    $(document).ready(function(){
 
-    var targetId = 'mapid'
+      var targetId = 'mapid'
 
-    setMapSize(targetId);
-    var mymap = renderMap(targetId);
-    var test_arg = 'this';
+      setMapSize(targetId);
+      var mymap = renderMap(targetId);
 
-    $('#dataset_options').children().each(function(){
-      $('#'+ this.id).click(function(){
-        $("li").removeClass("active")
-        $('#'+ this.id).addClass("active")
-        var features = $.ajax({
-          url: "/api/v4/service-area-spatial/full-set/?type=" + this.value,
-          beforeSend: function(){
-            $(".leaflet-pane").hide()
-          },
-          dataType : "json",
-          success: function(result){
-            mymap.eachLayer(function(layer){
-              if(layer._url && layer._url.includes('tile')){
-              }
-              else {
-                layer.remove()
-              }
-            })
-            $(".leaflet-pane").show()
-            name_key = result.name_key
-            result.data.forEach(function(feature){
-              feature_name = feature.properties[`${name_key}`];
-              var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
-            });
-          }
-        });
-      });
+      addLoadingIndicator(mymap)
+
+      var data_set_items = $('#dataset_options').children()
+      setupDataSetLinks(data_set_items, mymap)
+
     });
-
-  });
   </script>
 
 {% endblock %}

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -49,6 +49,55 @@
         setMapSize(targetId);
         var mymap = renderMap(targetId);
 
+        $('#national').click(mymap, function(){
+          var features = $.ajax({
+            url: "/api/v4/service-area-spatial/full-set/?type=0",
+            dataType : "json",
+            success: function(result){
+              result.forEach(function(feature){
+                var geoJSON = L.geoJson(feature).addTo(mymap);
+              });
+            }
+          });
+        });
+
+        $('#local_authority').click(mymap, function(){
+          var features = $.ajax({
+            url: "/api/v4/service-area-spatial/full-set/?type=2",
+            dataType : "json",
+            success: function(result){
+              result.forEach(function(feature){
+                var geoJSON = L.geoJson(feature).addTo(mymap);
+              });
+            }
+          });
+        });
+
+        $('#nhs').click(mymap, function(){
+          var features = $.ajax({
+            url: "/api/v4/service-area-spatial/full-set/?type=3",
+            dataType : "json",
+            success: function(result){
+              result.forEach(function(feature){
+                var geoJSON = L.geoJson(feature).addTo(mymap);
+              });
+            }
+          });
+        });
+
+        $('#hia').click(mymap, function(){
+          var features = $.ajax({
+            url: "/api/v4/service-area-spatial/full-set/?type=4",
+            dataType : "json",
+            success: function(result){
+              result.forEach(function(feature){
+                var geoJSON = L.geoJson(feature).addTo(mymap);
+              });
+            }
+          });
+        });
+
+
         // var serviceId =  "{{service.id}}";
         // if ("{{service.service_areas.all.0|safe}}" != ""){
         //   renderFeatures(mymap, serviceId);

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -13,17 +13,46 @@
 
           <p>Boundaries are set by different groups to help split the country into regions to ease management of concerns such as budget and responsibility. This can help to tailor the services provided to the needs of those who live in the boundary. A small charity may only have the resources and expertise to help individuals locally or be  ALISS supports several boundaries, such as:</p>
 
-          <ul id="dataset_options">
-            <li id="national" value=0><a href="#mapid">National</a></li>
-            <li id="local_authority" value=2><a href="#mapid">Local Authority</a></li>
-            <li id="nhs" value=3><a href="#mapid">NHS Healthboard</a></li>
-            <li id="hia" value=4><a href="#mapid">Integration Authority formerly HSCP</a></li>
-          </ul>
+          <!-- <div class="filter category"> -->
+            <label>Explore datasets</label>
+            <ol id="dataset_options" class="radio-list-links"  style="list-style: none;">
+              <li id="national" value=0>
+                <a>
+                  <span class="radio"></span>
+                  <span class="name">
+                    National
+                  </span>
+                </a>
+              </li>
+              <li id="local_authority" value=2 >
+                <a>
+                  <span class="radio"></span>
+                  <span class="name">
+                    Local Authority
+                  </span>
+                </a>
+              </li>
+              <li id="nhs" value=3>
+                <a>
+                  <span class="radio"></span>
+                  <span class="name">
+                    NHS Healthboard
+                  </span>
+                </a>
+              </li>
+              <li id="hia" value=4 >
+                <a>
+                  <span class="radio"></span>
+                  <span class="name">
+                    Integration Authority formerly HSCP
+                  </span>
+                </a>
+              </li>
+            </ol>
+          <!-- </div> -->
+
 
           <div id="mapid"></div>
-
-          <!-- <p>Although some boundaries overlap there are some which encompass others. For example a service could be available in Scotland in which case it is not necessary to also add local authroity boundaries as they would already be covered.</p> -->
-
 
         </div>
       </div>
@@ -53,6 +82,8 @@
 
         $('#dataset_options').children().each(function(){
           $('#'+ this.id).click(function(){
+            $("li").removeClass("active")
+            $('#'+ this.id).addClass("active")
             mymap.eachLayer(function(layer){
               if(layer._url && layer._url.includes('tile')){
               }
@@ -64,6 +95,7 @@
               url: "/api/v4/service-area-spatial/full-set/?type=" + this.value,
               dataType : "json",
               success: function(result){
+
                 name_key = result.name_key
                 result.data.forEach(function(feature){
                   feature_name = feature.properties[`${name_key}`];

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -8,12 +8,58 @@
     <div class="row">
       <div class="columns content">
         <div class="copy-container">
-          <h1>What is a Service Area?</h1>
-          <p></p>
+          <h1>What is a service area?</h1>
+          <p>A service area is a boundary in which a service is available. For example a although a service may have a physical location in the city centre the service may be available in all of Glasgow. This could be through home visits or communication about the local area. ALthough, who decides what is and isn't within Glasgow?</p>
+
+          <p>Boundaries are set by different groups to help split the country into regions to ease management of concerns such as budget and responsibility. This can help to tailor the services provided to the needs of those who live and work in the boundary. A small charity may only have the resources and expertise to help individuals locally or be  ALISS supports a numbers of boundaries such as:</p>
+
+          <ul>
+            <li id="national"><a>National</a></li>
+            <li id="local_authority"><a>Local Authority</a></li>
+            <li id="nhs"><a>NHS Healthboard</a></li>
+            <li id="hia"><a>Integration Authority formerly HSCP</a></li>
+          </ul>
+
+          <div id="mapid"></div>
+
+          <!-- <p>Although some boundaries overlap there are some which encompass others. For example a service could be available in Scotland in which case it is not necessary to also add local authroity boundaries as they would already be covered.</p> -->
+
         </div>
       </div>
     </div>
   </article>
 </main>
+{% endblock %}
+
+{% block before_body_close %}
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
+    integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
+    crossorigin=""/>
+
+    <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
+    integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
+    crossorigin="">
+    </script>
+
+    <script type="text/javascript">
+      $(document).ready(function(){
+
+        var targetId = 'mapid'
+
+        setMapSize(targetId);
+        var mymap = renderMap(targetId);
+
+        // var serviceId =  "{{service.id}}";
+        // if ("{{service.service_areas.all.0|safe}}" != ""){
+        //   renderFeatures(mymap, serviceId);
+        // }
+        //
+        // var locations = {{location_lat_longs|safe}};
+        // if (!$.isEmptyObject(locations)){
+        //   addLocations(mymap, locations);
+        // }
+
+      });
+    </script>
 
 {% endblock %}

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -14,15 +14,16 @@
           <p>Boundaries are set by different groups to help split the country into regions to ease management of concerns such as budget and responsibility. This can help to tailor the services provided to the needs of those who live and work in the boundary. A small charity may only have the resources and expertise to help individuals locally or be  ALISS supports a numbers of boundaries such as:</p>
 
           <ul>
-            <li id="national" value=0><a>National</a></li>
-            <li id="local_authority" value=2><a>Local Authority</a></li>
-            <li id="nhs" value=3><a>NHS Healthboard</a></li>
-            <li id="hia" value=4><a>Integration Authority formerly HSCP</a></li>
+            <li id="national" value=0><a href="#mapid">National</a></li>
+            <li id="local_authority" value=2><a href="#mapid">Local Authority</a></li>
+            <li id="nhs" value=3><a href="#mapid">NHS Healthboard</a></li>
+            <li id="hia" value=4><a href="#mapid">Integration Authority formerly HSCP</a></li>
           </ul>
 
           <div id="mapid"></div>
 
           <!-- <p>Although some boundaries overlap there are some which encompass others. For example a service could be available in Scotland in which case it is not necessary to also add local authroity boundaries as they would already be covered.</p> -->
+
 
         </div>
       </div>

--- a/aliss/templates/service/service_area_explanation.html
+++ b/aliss/templates/service/service_area_explanation.html
@@ -62,8 +62,10 @@
             url: "/api/v4/service-area-spatial/full-set/?type=" + $('#national').val(),
             dataType : "json",
             success: function(result){
-              result.forEach(function(feature){
-                var geoJSON = L.geoJson(feature).addTo(mymap);
+              name_key = result.name_key
+              result.data.forEach(function(feature){
+                feature_name = feature.properties[`${name_key}`];
+                var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
               });
             }
           });
@@ -81,8 +83,10 @@
             url: "/api/v4/service-area-spatial/full-set/?type=" + $('#local_authority').val(),
             dataType : "json",
             success: function(result){
-              result.forEach(function(feature){
-                var geoJSON = L.geoJson(feature).addTo(mymap);
+              name_key = result.name_key
+              result.data.forEach(function(feature){
+                feature_name = feature.properties[`${name_key}`];
+                var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
               });
             }
           });
@@ -100,8 +104,10 @@
             url: "/api/v4/service-area-spatial/full-set/?type=" + $('#nhs').val(),
             dataType : "json",
             success: function(result){
-              result.forEach(function(feature){
-                var geoJSON = L.geoJson(feature).addTo(mymap);
+              name_key = result.name_key
+              result.data.forEach(function(feature){
+                feature_name = feature.properties[`${name_key}`];
+                var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
               });
             }
           });
@@ -119,23 +125,14 @@
             url: "/api/v4/service-area-spatial/full-set/?type=" + $('#hia').val(),
             dataType : "json",
             success: function(result){
-              result.forEach(function(feature){
-                var geoJSON = L.geoJson(feature).addTo(mymap);
+              name_key = result.name_key
+              result.data.forEach(function(feature){
+                feature_name = feature.properties[`${name_key}`];
+                var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
               });
             }
           });
         });
-
-
-        // var serviceId =  "{{service.id}}";
-        // if ("{{service.service_areas.all.0|safe}}" != ""){
-        //   renderFeatures(mymap, serviceId);
-        // }
-        //
-        // var locations = {{location_lat_longs|safe}};
-        // if (!$.isEmptyObject(locations)){
-        //   addLocations(mymap, locations);
-        // }
 
       });
     </script>

--- a/aliss/tests/api/test_v4_service_area_spatial_view.py
+++ b/aliss/tests/api/test_v4_service_area_spatial_view.py
@@ -236,12 +236,24 @@ class v4ServiceAreaSpatialDataViewTestCase(TestCase):
         }
     ]
 
-    def test_get(self):
+    def test_get_feature(self):
         path = '/api/v4/service-area-spatial/?service_id=' + str(self.service.pk)
         response = self.client.get(path, format="json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
         self.assertEqual(response.data, self.json)
+
+    def test_get_full_dataset(self):
+        path = '/api/v4/service-area-spatial/full-set/?type=2'
+        response =  self.client.get(path, format="json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+
+    def test_get_dataset_name_key(self):
+        path = '/api/v4/service-area-spatial/full-set/?type=0'
+        response =  self.client.get(path, format="json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['name_key'], 'ctry17nm')
 
     def tearDown(self):
         self.service.delete()

--- a/aliss/urls/service.py
+++ b/aliss/urls/service.py
@@ -50,6 +50,12 @@ urlpatterns = [
         ServiceReportProblemView.as_view(),
         name='service_report_problem'
     ),
+    url(r'^service-area-explanation/$',
+        TemplateView.as_view(
+            template_name='service/service_area_explanation.html'
+        ),
+        name='service_area_explanation'
+    ),
     url("(?P<pk>[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})",
         ServiceDetailView.as_view(),
         name='service_detail'
@@ -64,5 +70,4 @@ urlpatterns = [
         ),
         name='service_report_problem_thanks'
     ),
-
 ]

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -673,43 +673,41 @@ $(document).ready(() => {
 
   window.clearFeatures = function(mymap){
     mymap.eachLayer(function(layer){
-      if(layer._url && layer._url.includes('tile')){
-      };
-      else {
-        layer.remove()
-      };
+      if(!(layer._url && layer._url.includes('tile'))){
+        layer.remove();
+      }
     });
   };
 
   window.addLoadingIndicator = function(mapid){
-    var loading_indicator = "<h3 id='loading' style='position: relative; top: 50%; text-align: center; margin: 0;'>Loading...</h3>"
-    $('#mapid').append(loading_indicator)
+    var loading_indicator = "<h3 id='loading' style='position: relative; top: 50%; text-align: center; margin: 0;'>Loading...</h3>";
+    $('#mapid').append(loading_indicator);
   };
 
   window.setupDataSetLinks = function(list_items, mymap){
     list_items.each(function(){
       $('#'+ this.id).click(function(){
-        list_items.removeClass("active")
-        $('#'+ this.id).addClass("active")
+        list_items.removeClass("active");
+        $('#'+ this.id).addClass("active");
         var features = $.ajax({
           url: "/api/v4/service-area-spatial/full-set/?type=" + this.value,
           beforeSend: function(){
-            $(".leaflet-pane").hide()
+            $(".leaflet-pane").hide();
           },
           dataType : "json",
           success: function(result){
-            clear_features(mymap)
-            $(".leaflet-pane").show()
-            name_key = result.name_key
+            clearFeatures(mymap);
+            $(".leaflet-pane").show();
+            var name_key = result.name_key;
             result.data.forEach(function(feature){
-              feature_name = feature.properties[`${name_key}`];
+              var feature_name = feature.properties[`${name_key}`];
               var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
             });
           }
         });
       });
-    })
-  }
+    });
+  };
 
 
   svg4everybody();

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -671,6 +671,47 @@ $(document).ready(() => {
     });
   };
 
+  window.clearFeatures = function(mymap){
+    mymap.eachLayer(function(layer){
+      if(layer._url && layer._url.includes('tile')){
+      };
+      else {
+        layer.remove()
+      };
+    });
+  };
+
+  window.addLoadingIndicator = function(mapid){
+    var loading_indicator = "<h3 id='loading' style='position: relative; top: 50%; text-align: center; margin: 0;'>Loading...</h3>"
+    $('#mapid').append(loading_indicator)
+  };
+
+  window.setupDataSetLinks = function(list_items, mymap){
+    list_items.each(function(){
+      $('#'+ this.id).click(function(){
+        list_items.removeClass("active")
+        $('#'+ this.id).addClass("active")
+        var features = $.ajax({
+          url: "/api/v4/service-area-spatial/full-set/?type=" + this.value,
+          beforeSend: function(){
+            $(".leaflet-pane").hide()
+          },
+          dataType : "json",
+          success: function(result){
+            clear_features(mymap)
+            $(".leaflet-pane").show()
+            name_key = result.name_key
+            result.data.forEach(function(feature){
+              feature_name = feature.properties[`${name_key}`];
+              var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
+            });
+          }
+        });
+      });
+    })
+  }
+
+
   svg4everybody();
   handleTabs();
   checkMaxCategories();


### PR DESCRIPTION
## Description
- Currently, from user behaviour, it would appear ServiceAreas are not being added as intended. 

- Many services state a service covers single service areas such as East Lothian but also Scotland. As Scotland encompasses East Lothian the smaller service area is redundant. 

- This could add confusion for users who are searching for services but also suggests those adding services may not fully understand the purpose of ServiceAreas. 

- To better educate users created a new page which explains them as a concept.

- Added copy to explain ServiceAreas and a list of radio buttons of ServiceArea dataset which populate a map with the appropriate features. 

- To make this data available a new API endpoint was added which takes the ServiceArea type and returns the full geoJSON data set as well as the appropriate key to access the feature name for creating labels. 

- Also updated the method which returns features to add a feature to return all of a given dataset to be served by the API endpoint. 

## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/89

## Relevant Screenshots 
<img width="880" alt="Screenshot 2019-08-12 at 12 25 53" src="https://user-images.githubusercontent.com/36415632/62942323-f2267f80-bdcf-11e9-8517-9e975a0faae9.png">

<img width="873" alt="Screenshot 2019-08-12 at 15 39 13" src="https://user-images.githubusercontent.com/36415632/62942334-f6eb3380-bdcf-11e9-9fe0-70d931a0ae3f.png">

## Testing
- Added basic tests to check the API endpoint returns the expected data. 
- Manually tested the JS code to ensure it works as expected in the dev environment.

## Follow Up
- [ ] Discuss the feature and give feedback.
- [ ] Add links to allow users to navigate the service explanation page. 
