### PR TITLE
Enhance/client validation service areas

### DIFF
--- a/aliss/forms/service.py
+++ b/aliss/forms/service.py
@@ -9,7 +9,7 @@ def service_areas_as_choices():
     data = ServiceArea.objects.order_by('type', 'code')
 
     for k, g in groupby(data, lambda x: x.get_type_display()):
-        choices.append([k, list([[item.pk, item.name] for item in g])])
+        choices.append([k, list([[item.pk, (item.name + " (" + item.get_type_display() + ")")] for item in g])])
 
     return choices
 

--- a/aliss/templates/service/update.html
+++ b/aliss/templates/service/update.html
@@ -34,69 +34,7 @@
 <script type="text/javascript">
   $(document).ready(function(){
 
-    var regionalWarning = "To add national service area remove all regional."
-    var nationalWarning = "To add regional service areas remove all national."
-    var mixedServiceAreaWarning = "To help users please either use national or regional service areas."
-
-    var serviceArealabel = $('label[for="id_service_areas"]')
-
-    $(serviceArealabel).append("<h4 id='id_service_area_warning'></h4>")
-
-    var selectSpanTarget = {}
-    $('#id_service_areas').siblings().each(function(index, item){
-      if ($(item).is("span")){
-        selectSpanTarget = item
-      }
-    })
-
-    $(selectSpanTarget).click(function(){
-      nationalOptGroups = []
-      regionalOptGroups = []
-
-      var nationalOptions = []
-      var regionalOptions = []
-      var optionGroups = $('#id_service_areas').children()
-
-      optionGroups.each(function(index, group){
-        if (group.label == "Country"){
-          nationalOptGroups.push(group)
-          var groupArray = Array.from(group.children)
-          $.merge(nationalOptions, groupArray)
-        }
-        else {
-          regionalOptGroups.push(group)
-          var groupArray = Array.from(group.children)
-          $.merge(regionalOptions, groupArray)
-        }
-
-      });
-
-      function checkSelected(option){
-        if (option.selected){
-          return option
-        }
-      }
-
-      var nationalSelectedCount = nationalOptions.filter(checkSelected).length
-      var regionalSelectedCount = regionalOptions.filter(checkSelected).length
-
-      if (nationalSelectedCount == 0 && regionalSelectedCount > 0){
-        $('#id_service_area_warning').text(regionalWarning)
-        $('li[aria-label="Country"]').hide()
-      }
-
-      if (nationalSelectedCount > 0 && regionalSelectedCount == 0){
-        $('#id_service_area_warning').text(nationalWarning)
-        $('li[aria-label="Local Authority"]').hide()
-        $('li[aria-label="Health Board"]').hide()
-        $('li[aria-label="Integration Authority (HSCP)"]').hide()
-      }
-
-      if (nationalSelectedCount > 0 && regionalSelectedCount > 0){
-        $('#id_service_area_warning').text(mixedServiceAreaWarning)
-      }
-
-    })
+    serviceAreaClientValidation()
 
   });
 </script>

--- a/aliss/templates/service/update.html
+++ b/aliss/templates/service/update.html
@@ -35,15 +35,22 @@
   $(document).ready(function(){
 
     console.log('Test')
+    nationalOptGroups = []
+    regionalOptGroups = []
+
     var nationalOptions = []
     var regionalOptions = []
-    var optionGroups = $('#id_service_areas').children().each(function(index, group){
+    var optionGroups = $('#id_service_areas').children()
+
+    optionGroups.each(function(index, group){
       if (group.label == "Country"){
         console.log('Group: ', group)
+        nationalOptGroups.push(group)
         var groupArray = Array.from(group.children)
         $.merge(nationalOptions, groupArray)
       }
       else {
+        regionalOptGroups.push(group)
         console.log('Group: ', group)
         var groupArray = Array.from(group.children)
         $.merge(regionalOptions, groupArray)
@@ -68,11 +75,42 @@
 
     var regionalWarning = "<h4 id=regional_warning>To add national service area remove all regional</h4>"
 
-    var nationWarning = "<h4 id=national_warning>To add regional service areas remove all national.</h4>"
+    var nationalWarning = "<h4 id=national_warning>To add regional service areas remove all national.</h4>"
+
+    var mixedServiceAreaWarning = "<h4 id=national_warning>To help users please either use national OR regional service areas.</h4>"
 
     var serviceArealabel = $('label[for="id_service_areas"]')
     serviceArealabel.append()
 
+    if (nationalSelectedCount == 0 && regionalSelectedCount > 0){
+      optionGroups.each(function(index, element){
+        if (element.label == "Country"){
+          $('li[aria-label="Country"]').hide()
+        }
+      })
+    }
+
+    if (regionalSelectedCount == 0 && nationalSelectedCount > 0){
+      regionalOptions.hide()
+    }
+    if (regionalSelectedCount > 0 && nationalSelectedCount > 0){
+      serviceArealabel.append(mixedServiceAreaWarning)
+    }
+
+    var selectSpanTarget = {}
+    $('#id_service_areas').siblings().each(function(index, item){
+      if ($(item).is("span")){
+        selectSpanTarget = item
+      }
+    })
+
+    $(selectSpanTarget).click(function(){
+      console.log('Test')
+      $('li[aria-label="Country"]').hide()
+      $('li[aria-label="Local Authority"]').hide()
+      $('li[aria-label="Health Board"]').hide()
+      $('li[aria-label="Integration Authority (HSCP)"]').hide()
+    })
 
   });
 </script>

--- a/aliss/templates/service/update.html
+++ b/aliss/templates/service/update.html
@@ -28,3 +28,37 @@
     </section>
 </main>
 {% endblock %}
+
+{% block before_body_close%}
+
+<script type="text/javascript">
+  $(document).ready(function(){
+
+    console.log('Test')
+    var selected_options = $('#id_service_areas').children().children().filter(":selected")
+    var country_options = []
+    var regional_options = []
+    var option_groups = $('#id_service_areas').children().each(function(index, group){
+      if (group.label == "Country"){
+        console.log('Group: ', group)
+        var group_array = Array.from(group.children)
+        $.merge(country_options, group_array)
+      }
+      else {
+        console.log('Group: ', group)
+        var group_array = Array.from(group.children)
+        $.merge(regional_options, group_array)
+      }
+
+    });
+    console.log("Country Options: ", country_options)
+    console.log("Regional Options: ", regional_options)
+    
+
+
+
+
+  });
+</script>
+
+{% endblock %}

--- a/aliss/templates/service/update.html
+++ b/aliss/templates/service/update.html
@@ -34,68 +34,13 @@
 <script type="text/javascript">
   $(document).ready(function(){
 
-    console.log('Test')
-    nationalOptGroups = []
-    regionalOptGroups = []
-
-    var nationalOptions = []
-    var regionalOptions = []
-    var optionGroups = $('#id_service_areas').children()
-
-    optionGroups.each(function(index, group){
-      if (group.label == "Country"){
-        console.log('Group: ', group)
-        nationalOptGroups.push(group)
-        var groupArray = Array.from(group.children)
-        $.merge(nationalOptions, groupArray)
-      }
-      else {
-        regionalOptGroups.push(group)
-        console.log('Group: ', group)
-        var groupArray = Array.from(group.children)
-        $.merge(regionalOptions, groupArray)
-      }
-
-    });
-    console.log("National Options: ", nationalOptions)
-    console.log("Regional Options: ", regionalOptions)
-
-
-    function checkSelected(option){
-      if (option.selected){
-        return option
-      }
-    }
-
-    var nationalSelectedCount = nationalOptions.filter(checkSelected).length
-    var regionalSelectedCount = regionalOptions.filter(checkSelected).length
-
-    console.log(regionalSelectedCount)
-    console.log(nationalSelectedCount)
-
-    var regionalWarning = "<h4 id=regional_warning>To add national service area remove all regional</h4>"
-
-    var nationalWarning = "<h4 id=national_warning>To add regional service areas remove all national.</h4>"
-
-    var mixedServiceAreaWarning = "<h4 id=national_warning>To help users please either use national OR regional service areas.</h4>"
+    var regionalWarning = "To add national service area remove all regional."
+    var nationalWarning = "To add regional service areas remove all national."
+    var mixedServiceAreaWarning = "To help users please either use national or regional service areas."
 
     var serviceArealabel = $('label[for="id_service_areas"]')
-    serviceArealabel.append()
 
-    if (nationalSelectedCount == 0 && regionalSelectedCount > 0){
-      optionGroups.each(function(index, element){
-        if (element.label == "Country"){
-          $('li[aria-label="Country"]').hide()
-        }
-      })
-    }
-
-    if (regionalSelectedCount == 0 && nationalSelectedCount > 0){
-      regionalOptions.hide()
-    }
-    if (regionalSelectedCount > 0 && nationalSelectedCount > 0){
-      serviceArealabel.append(mixedServiceAreaWarning)
-    }
+    $(serviceArealabel).append("<h4 id='id_service_area_warning'></h4>")
 
     var selectSpanTarget = {}
     $('#id_service_areas').siblings().each(function(index, item){
@@ -105,11 +50,52 @@
     })
 
     $(selectSpanTarget).click(function(){
-      console.log('Test')
-      $('li[aria-label="Country"]').hide()
-      $('li[aria-label="Local Authority"]').hide()
-      $('li[aria-label="Health Board"]').hide()
-      $('li[aria-label="Integration Authority (HSCP)"]').hide()
+      nationalOptGroups = []
+      regionalOptGroups = []
+
+      var nationalOptions = []
+      var regionalOptions = []
+      var optionGroups = $('#id_service_areas').children()
+
+      optionGroups.each(function(index, group){
+        if (group.label == "Country"){
+          nationalOptGroups.push(group)
+          var groupArray = Array.from(group.children)
+          $.merge(nationalOptions, groupArray)
+        }
+        else {
+          regionalOptGroups.push(group)
+          var groupArray = Array.from(group.children)
+          $.merge(regionalOptions, groupArray)
+        }
+
+      });
+
+      function checkSelected(option){
+        if (option.selected){
+          return option
+        }
+      }
+
+      var nationalSelectedCount = nationalOptions.filter(checkSelected).length
+      var regionalSelectedCount = regionalOptions.filter(checkSelected).length
+
+      if (nationalSelectedCount == 0 && regionalSelectedCount > 0){
+        $('#id_service_area_warning').text(regionalWarning)
+        $('li[aria-label="Country"]').hide()
+      }
+
+      if (nationalSelectedCount > 0 && regionalSelectedCount == 0){
+        $('#id_service_area_warning').text(nationalWarning)
+        $('li[aria-label="Local Authority"]').hide()
+        $('li[aria-label="Health Board"]').hide()
+        $('li[aria-label="Integration Authority (HSCP)"]').hide()
+      }
+
+      if (nationalSelectedCount > 0 && regionalSelectedCount > 0){
+        $('#id_service_area_warning').text(mixedServiceAreaWarning)
+      }
+
     })
 
   });

--- a/aliss/templates/service/update.html
+++ b/aliss/templates/service/update.html
@@ -35,27 +35,43 @@
   $(document).ready(function(){
 
     console.log('Test')
-    var selected_options = $('#id_service_areas').children().children().filter(":selected")
-    var country_options = []
-    var regional_options = []
-    var option_groups = $('#id_service_areas').children().each(function(index, group){
+    var nationalOptions = []
+    var regionalOptions = []
+    var optionGroups = $('#id_service_areas').children().each(function(index, group){
       if (group.label == "Country"){
         console.log('Group: ', group)
-        var group_array = Array.from(group.children)
-        $.merge(country_options, group_array)
+        var groupArray = Array.from(group.children)
+        $.merge(nationalOptions, groupArray)
       }
       else {
         console.log('Group: ', group)
-        var group_array = Array.from(group.children)
-        $.merge(regional_options, group_array)
+        var groupArray = Array.from(group.children)
+        $.merge(regionalOptions, groupArray)
       }
 
     });
-    console.log("Country Options: ", country_options)
-    console.log("Regional Options: ", regional_options)
-    
+    console.log("National Options: ", nationalOptions)
+    console.log("Regional Options: ", regionalOptions)
 
 
+    function checkSelected(option){
+      if (option.selected){
+        return option
+      }
+    }
+
+    var nationalSelectedCount = nationalOptions.filter(checkSelected).length
+    var regionalSelectedCount = regionalOptions.filter(checkSelected).length
+
+    console.log(regionalSelectedCount)
+    console.log(nationalSelectedCount)
+
+    var regionalWarning = "<h4 id=regional_warning>To add national service area remove all regional</h4>"
+
+    var nationWarning = "<h4 id=national_warning>To add regional service areas remove all national.</h4>"
+
+    var serviceArealabel = $('label[for="id_service_areas"]')
+    serviceArealabel.append()
 
 
   });

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -784,6 +784,8 @@ $(document).ready(() => {
       }
 
     });
+
+    $(selectSpanTarget).trigger('click');
   };
 
 

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -718,7 +718,7 @@ $(document).ready(() => {
   };
 
   window.serviceAreaClientValidation = function(){
-    var regionalWarning = "To add national service area remove all regional.";
+    var regionalWarning = "To add a national service area remove all regional.";
     var nationalWarning = "To add regional service areas remove all national.";
     var mixedServiceAreaWarning = "Please select either national or regional service areas.";
     var standardMessage = "Manage service areas below.";

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -717,6 +717,75 @@ $(document).ready(() => {
     });
   };
 
+  window.serviceAreaClientValidation = function(){
+    var regionalWarning = "To add national service area remove all regional.";
+    var nationalWarning = "To add regional service areas remove all national.";
+    var mixedServiceAreaWarning = "Please select either national or regional service areas.";
+    var standardMessage = "Manage service areas below.";
+
+    var serviceArealabel = $('label[for="id_service_areas"]');
+
+    $(serviceArealabel).append(`<h6 id='id_service_area_warning'>${standardMessage}</h6>`);
+
+    var selectSpanTarget = {};
+    $('#id_service_areas').siblings().each(function(index, item){
+      if ($(item).is("span")){
+        selectSpanTarget = item;
+      }
+    });
+
+    $(selectSpanTarget).click(function(){
+
+      var nationalOptions = [];
+      var regionalOptions = [];
+      var optionGroups = $('#id_service_areas').children();
+
+      optionGroups.each(function(index, group){
+        var groupArray = [];
+
+        if (group.label == "Country"){
+          groupArray = Array.from(group.children);
+          $.merge(nationalOptions, groupArray);
+        }
+        else {
+          groupArray = Array.from(group.children);
+          $.merge(regionalOptions, groupArray);
+        }
+
+      });
+
+      function checkSelected(option){
+        if (option.selected){
+          return option;
+        }
+      }
+
+      var nationalSelectedCount = nationalOptions.filter(checkSelected).length;
+      var regionalSelectedCount = regionalOptions.filter(checkSelected).length;
+
+      if (nationalSelectedCount == 0 && regionalSelectedCount > 0){
+        $('#id_service_area_warning').text(regionalWarning);
+        $('li[aria-label="Country"]').hide();
+      }
+
+      if (nationalSelectedCount > 0 && regionalSelectedCount == 0){
+        $('#id_service_area_warning').text(nationalWarning);
+        $('li[aria-label="Local Authority"]').hide();
+        $('li[aria-label="Health Board"]').hide();
+        $('li[aria-label="Integration Authority (HSCP)"]').hide();
+      }
+
+      if (nationalSelectedCount > 0 && regionalSelectedCount > 0){
+        $('#id_service_area_warning').text(mixedServiceAreaWarning);
+      }
+
+      if (nationalSelectedCount == 0 && regionalSelectedCount == 0){
+        $('#id_service_area_warning').text(standardMessage);
+      }
+
+    });
+  };
+
 
   svg4everybody();
   handleTabs();


### PR DESCRIPTION
## Description
- Currently, users are selecting national and regional service areas which can cause confusion.

- Also, it can be hard for users to determine which service area data set they're choosing from. 

- Added JS to display messages dependent on which service area types were selected and then hiding or showing service areas to make it easier for users to select correctly. 


## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/99


## Relevant Screenshots 

If no service areas are yet selected:

<img width="527" alt="Screenshot 2019-08-23 at 12 41 29" src="https://user-images.githubusercontent.com/36415632/63591018-7f728c80-c5a5-11e9-82c3-3ae727526c29.png">

Only nationwide options available when one is selected:

<img width="535" alt="Screenshot 2019-08-23 at 12 41 36" src="https://user-images.githubusercontent.com/36415632/63591029-839eaa00-c5a5-11e9-94d3-edeace35c642.png">

Only regional service areas available when one is selected:
<img width="524" alt="Screenshot 2019-08-23 at 12 41 50" src="https://user-images.githubusercontent.com/36415632/63591033-87323100-c5a5-11e9-97a6-a49fc020e200.png">



## Testing
- As the majority of the feature is in JS visually tested. 

## Follow Up
- [ ] May need to run gulp to recompile JS.
- [ ] Discuss service area section of form refactor. 