### PR TITLE
Enhance/service area explanation links

### DIFF
--- a/aliss/templates/partials/forms/multiselect_field.html
+++ b/aliss/templates/partials/forms/multiselect_field.html
@@ -6,6 +6,9 @@
       </span>
       {% endif %}
     </label>
+    {% if add_service_area_explanation_link %}
+      {% include 'service/partials/service_area_explanation_link.html' %}
+    {% endif %}
     {% if annotation %}
       <p class="small"><i class="fa fa-info-circle" aria-hidden="true"></i> {{ annotation }}</p>
     {% endif %}

--- a/aliss/templates/service/detail.html
+++ b/aliss/templates/service/detail.html
@@ -283,6 +283,7 @@
                 <li style="margin-right:1rem;" title="{{ area.type_name }}"> · {{area.name}} <span class="area-type-{{area.type}}">({{ area.type_name }})</span></li>
               {% endfor %}
             </ul>
+            <p>To learn more about <a href="{% url 'service_area_explanation' %}" target="_blank">service areas.</a>
           {% endif %}
           <div id='mapid'></div>
         </div>

--- a/aliss/templates/service/detail.html
+++ b/aliss/templates/service/detail.html
@@ -283,7 +283,7 @@
                 <li style="margin-right:1rem;" title="{{ area.type_name }}"> · {{area.name}} <span class="area-type-{{area.type}}">({{ area.type_name }})</span></li>
               {% endfor %}
             </ul>
-            <p>To learn more about <a href="{% url 'service_area_explanation' %}" target="_blank">service areas.</a></p>
+            {% include 'service/partials/service_area_explanation_link.html' %}
           {% endif %}
           <div id='mapid'></div>
         </div>

--- a/aliss/templates/service/detail.html
+++ b/aliss/templates/service/detail.html
@@ -283,7 +283,7 @@
                 <li style="margin-right:1rem;" title="{{ area.type_name }}"> · {{area.name}} <span class="area-type-{{area.type}}">({{ area.type_name }})</span></li>
               {% endfor %}
             </ul>
-            <p>To learn more about <a href="{% url 'service_area_explanation' %}" target="_blank">service areas.</a>
+            <p>To learn more about <a href="{% url 'service_area_explanation' %}" target="_blank">service areas.</a></p>
           {% endif %}
           <div id='mapid'></div>
         </div>

--- a/aliss/templates/service/forms/service_form.html
+++ b/aliss/templates/service/forms/service_form.html
@@ -90,5 +90,5 @@
     </fieldset>
 </div>
 <div class="f-row">
-    {% include 'partials/forms/multiselect_field.html' with field=form.service_areas annotation="If you select Scotland or United Kingdom as a service area, your listing will not appear when a user filters their search to only show local - not national - services." %}
+    {% include 'partials/forms/multiselect_field.html' with field=form.service_areas annotation="If you select Scotland or United Kingdom as a service area, your listing will not appear when a user filters their search to only show local - not national - services." add_service_area_explanation_link=True %}
 </div>

--- a/aliss/templates/service/partials/service_area_explanation_link.html
+++ b/aliss/templates/service/partials/service_area_explanation_link.html
@@ -1,0 +1,3 @@
+{% load aliss %}
+
+<p class="small">To learn more about <a href="{% url 'service_area_explanation' %}" target="_blank">service areas.</a></p>


### PR DESCRIPTION
## Description
- Although the service area explanation page has been added there is currently not a means of reaching the page without typing in the URL. 

- Added links on the pages where a user may want to learn more about service areas such as the service create and update forms as well as the service detail page. 

## Related Issue/Issues
https://github.com/Mike-Heneghan/ALISS/issues/97


## Relevant Screenshots 
Link on detial page:
<img width="476" alt="Screenshot 2019-08-30 at 14 43 19" src="https://user-images.githubusercontent.com/36415632/64028168-0d1c2200-cb3a-11e9-9132-6e762c7b2d74.png">

Link on service create:
<img width="511" alt="Screenshot 2019-08-30 at 15 05 34" src="https://user-images.githubusercontent.com/36415632/64028183-13120300-cb3a-11e9-99b1-c5af0a19e445.png">

Link on service update: 
<img width="742" alt="Screenshot 2019-08-30 at 14 42 04" src="https://user-images.githubusercontent.com/36415632/64028188-15745d00-cb3a-11e9-8445-3c75d15dd921.png">


## Testing
- As only adding a link and the copy is subject to change I did not add an automated test. 

- Tested the link manually from the three pages where it was added. 

## Follow Up
- [ ] Feedback on the feature. 
