### PR TITLE
Enhance/filter language

### DIFF
--- a/aliss/templates/search/partials/results-content.html
+++ b/aliss/templates/search/partials/results-content.html
@@ -122,6 +122,9 @@
                 By best match
               </span>
             </a>
+            <span data-tooltip aria-haspopup="true" class="has-tip right" data-disable-hover="false" tabindex="2" title="This is a combination of nearest first and keyword match.">
+              <i class="fa fa-question-circle" aria-hidden="true"></i>
+            </span>
           </li>
           <li {% if request.GET.sort == "nearest" %}class="active"{% endif %}>
             <a href="{% query_transform request sort="nearest" %}">

--- a/aliss/templates/search/partials/results-content.html
+++ b/aliss/templates/search/partials/results-content.html
@@ -135,7 +135,7 @@
             <a href="{% query_transform request sort="keyword" %}">
               <span class="radio"></span>
               <span class="name">
-                By best keyword match
+                By keyword match
               </span>
             </a>
           </li>

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -219,9 +219,25 @@ ul.service-areas li {
 }
 
 a span.has-tip {
-  cursor: pointer; 
+  cursor: pointer;
 }
 a span.has-tip:hover {
   text-decoration: underline;
   color: $secondary;
+}
+
+div.filter.sorting span.has-tip{
+  cursor: help;
+  .fa {
+    opacity: 0.3;
+    vertical-align: middle;
+  }
+  color: $medium-gray;
+  font-size: $d-fs;
+}
+
+div.filter.sorting span.has-tip:hover{
+  .fa { opacity: 1.0; }
+  text-decoration: none;
+  color: $medium-gray;
 }


### PR DESCRIPTION
## Description
- When searching ALISS users can refine results by keyword which presents them with three sorting options. 

- Updated the language of the last filter for clarity. 

- Added a tooltip to the 'By best match' option to explain how it is determined.

- Needed to add custom styling to keep the tooltip styling consistent with other parts of the app. 


## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/102
- https://github.com/Mike-Heneghan/ALISS/issues?page=2&q=is%3Aissue+is%3Aclosed


## Relevant Screenshots 
Without cutom styling:
<img width="248" alt="Screenshot 2019-09-12 at 16 38 20" src="https://user-images.githubusercontent.com/36415632/64800482-98f06e00-d57e-11e9-9511-fb2161fdd79b.png">

With custom styling:
<img width="267" alt="Screenshot 2019-09-12 at 16 38 33" src="https://user-images.githubusercontent.com/36415632/64800467-91c96000-d57e-11e9-912b-49a609d79dc1.png">
<img width="592" alt="Screenshot 2019-09-12 at 16 38 42" src="https://user-images.githubusercontent.com/36415632/64800472-94c45080-d57e-11e9-8f59-46705b5db434.png">


## Testing
- As styling the change was tested manually and no automated tests results changed as a result of the restyle. 

## Follow Up
- [ ] May need to run `gulp sass` to recompile static css files. 
