### PR TITLE
Enhance/search place redirect

### DIFF
--- a/aliss/templates/homepage.html
+++ b/aliss/templates/homepage.html
@@ -82,7 +82,7 @@
         minCharNumber: 3,
         list: {
           match: { enabled: true },
-          onChooseEvent: function(e){ 
+          onChooseEvent: function(e){
             var value = $("#postcode").getSelectedItemData().postcode;
             $("#postcode").val(value).trigger("change");
           }
@@ -98,6 +98,14 @@
           }
         }
       });
+
+      $('.search-box button').click(function(){
+        var firstOption = $('#eac-container-postcode li div:visible').first();
+        if (firstOption.length){
+          $('#eac-container-postcode li div:visible').first().click();
+        }
+      })
+
     });
   </script>
 {% endblock %}

--- a/aliss/templates/homepage.html
+++ b/aliss/templates/homepage.html
@@ -90,20 +90,22 @@
       };
 
       $("#postcode").easyAutocomplete(options);
-      $('#postcode').keypress(function(e){
-        if (e.which === 13) {
-          var firstOption = $('#eac-container-postcode li div:visible').first();
-          if (firstOption.length){
-            $('#eac-container-postcode li div:visible').first().click();
-          }
-        }
-      });
 
-      $('.search-box button').click(function(){
+      var triggerAutoCompleteSelection = function() {
         var firstOption = $('#eac-container-postcode li div:visible').first();
         if (firstOption.length){
           $('#eac-container-postcode li div:visible').first().click();
         }
+      }
+
+      $('#postcode').keypress(function(e){
+        if (e.which === 13) {
+          triggerAutoCompleteSelection()
+        }
+      });
+
+      $('.search-box button').click(function(){
+        triggerAutoCompleteSelection()
       })
 
     });

--- a/aliss/tests/views/test_search_view.py
+++ b/aliss/tests/views/test_search_view.py
@@ -85,7 +85,6 @@ class SearchViewTestCase(TestCase):
         self.multi_location_service.locations.add(self.location_glasgow_not_in_district)
         self.multi_location_service.save()
 
-
     def test_get(self):
         response = self.client.get('/search/?postcode=G2+4AA')
         self.assertEqual(response.status_code, 200)
@@ -205,6 +204,22 @@ class SearchViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "My Testing Service")
         self.assertNotContains(response, "Nearest location 1.4km")
+
+    def test_placename_search_redirect(self):
+        edinburgh_postcode = Postcode.objects.get_or_create(pk="EH1 1BQ", defaults={
+                'postcode': 'EH1 1BQ', 'postcode_district': 'EH1',
+                'postcode_sector': 'EH1 1', 'latitude': 55.95263002,
+                'longitude': -3.19132872, 'council_area_2011_code': 'S12000036',
+                'health_board_area_2014_code': 'S08000024',
+                'integration_authority_2016_code': 'S37000012',
+                'place_name': 'Edinburgh', 'slug': 'edinburgh'
+            }
+        )
+        postcode = Postcode.objects.get(slug='edinburgh')
+        self.assertEqual(edinburgh_postcode[0], postcode)
+        response = self.client.get('/search/?postcode=edinburgh+')
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, '/search/?postcode=EH1+1BQ')
 
     def tearDown(self):
         Fixtures.organisation_teardown()

--- a/aliss/views/search.py
+++ b/aliss/views/search.py
@@ -3,7 +3,7 @@ from django.views.generic import View, TemplateView
 from django.views.generic.list import MultipleObjectMixin
 from django.conf import settings
 from django.urls import reverse
-from django.http import HttpResponseRedirect, HttpResponse
+from django.http import HttpResponseRedirect
 
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.connections import connections
@@ -27,7 +27,6 @@ class SearchView(MultipleObjectMixin, TemplateView):
     paginate_by = 10
 
     def get_context_data(self, **kwargs):
-        kwargs['postcode'] = self.postcode
         context = super(SearchView, self).get_context_data(**kwargs)
         context['postcode'] = self.postcode
         service_area = self.postcode.get_local_authority()

--- a/aliss/views/search.py
+++ b/aliss/views/search.py
@@ -21,9 +21,6 @@ from aliss.search import (
     combined_order
 )
 
-import re
-
-
 class SearchView(MultipleObjectMixin, TemplateView):
     template_name = 'search/results.html'
     #paginator_class = ESPaginator
@@ -66,12 +63,11 @@ class SearchView(MultipleObjectMixin, TemplateView):
                 try:
                     lower_searched = searched_term.lower().strip()
                     matched_postcode = Postcode.objects.get(slug=lower_searched).postcode
-                    processed_postcode = matched_postcode.upper().strip()
-
+                    processed_postcode = matched_postcode.upper().strip().replace(' ', '+')
                     return HttpResponseRedirect(
                         "{url}?postcode={postcode}".format(
                             url=reverse('search'),
-                            postcode=matched_postcode,
+                            postcode=processed_postcode,
                         ))
                 except Postcode.DoesNotExist:
                     invalid_area = search_form.cleaned_data.get('postcode', None) == None


### PR DESCRIPTION
## Description
- It was noticed some users were searching by placename but not successfully returning results.

- This could have been due to a number of things. If the user was on a slow connection the JS relies on the autocomplete options loading and being visible. 

- It also could be that if the user doesn't select the dropdown but clicks search the conversion isn't automatically done before the form is submitted. 

- Also if a user enters their placename followed by a space then the autocomplete option disappear meaning the user can't select them and no automatic conversion is done. 

- To overcome this added an event listener for `click` on the search button to use the first autocomplete option as the postcode.

- Also added a fallback that if a request is made with a non-postcode string a lookup is done for a matching postcode and if found the user is redirected to a search with that postcode. 

## Related Issue/Issues

- https://github.com/Mike-Heneghan/ALISS/issues/103
- https://github.com/Mike-Heneghan/ALISS/issues/104


## Relevant Screenshots 
N/A 

## Testing
- This feature was manually tested and did not impact any of the existing tests. 

## Follow Up
- [ ] Discuss the proposed solution.  