### PR TITLE
Enhance/places fallback improvement

### DIFF
--- a/aliss/templatetags/aliss.py
+++ b/aliss/templatetags/aliss.py
@@ -216,9 +216,12 @@ def content_render(path, suffix = ""):
         path_list = path.split("/")
         while("" in path_list):
             path_list.remove("")
-        slug = "-".join(path_list)
+        processed_list = []
+        for item in path_list:
+            processed_list.append(item.lower())
+        slug = "-".join(processed_list)
     else:
-        slug = path
+        slug = path.lower().strip()
     try:
         content = ContentBlock.objects.get(slug=slug)
     except ContentBlock.DoesNotExist:

--- a/aliss/tests/views/test_places_view.py
+++ b/aliss/tests/views/test_places_view.py
@@ -104,7 +104,6 @@ class PlacesViewTestCase(TestCase):
 
     def test_invalid_landing_page_uppercase_placename(self):
         place_name_slug = self.postcode.slug
-        print(place_name_slug)
         response = self.client.get('/places/Glasgow/')
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, '/search/?postcode=G2+4AA')

--- a/aliss/tests/views/test_places_view.py
+++ b/aliss/tests/views/test_places_view.py
@@ -95,6 +95,20 @@ class PlacesViewTestCase(TestCase):
         self.assertContains(response, custom_meta_desc)
         self.assertContains(response, custom_meta_title)
 
+    def test_valid_landing_page_uppercase_placename(self):
+        custom_content = "<h1>Edinburgh title test</h1><p>New landing page content for a place.</p>"
+        ContentBlock.objects.create(slug='places-edinburgh', body=custom_content)
+        response = self.client.get('/places/Edinburgh/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, custom_content)
+
+    def test_invalid_landing_page_uppercase_placename(self):
+        place_name_slug = self.postcode.slug
+        print(place_name_slug)
+        response = self.client.get('/places/Glasgow/')
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, '/search/?postcode=G2+4AA')
+
     def tearDown(self):
         for block in ContentBlock.objects.all():
             block.delete()

--- a/aliss/tests/views/test_places_view.py
+++ b/aliss/tests/views/test_places_view.py
@@ -102,11 +102,24 @@ class PlacesViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, custom_content)
 
-    def test_invalid_landing_page_uppercase_placename(self):
+    def test_invalid_landing_page_uppercase_valid_placename_redirect_search(self):
         place_name_slug = self.postcode.slug
         response = self.client.get('/places/Glasgow/')
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, '/search/?postcode=G2+4AA')
+
+    def test_valid_landing_page_uppercase_placename_uppercase_category(self):
+        custom_content = "<p>Conditions services for Glasgow</p>"
+        ContentBlock.objects.create(slug='places-glasgow-conditions', body=custom_content)
+        response = self.client.get('/places/Glasgow/Conditions/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, custom_content)
+
+    def test_invalid_landing_page_uppercase_placename_uppercase_category_standard_copy(self):
+        response = self.client.get('/places/Glasgow/Conditions/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Glasgow')
+        self.assertContains(response, 'Conditions')
 
     def tearDown(self):
         for block in ContentBlock.objects.all():

--- a/aliss/views/places.py
+++ b/aliss/views/places.py
@@ -35,9 +35,11 @@ class PlaceCategoryView(MultipleObjectMixin, TemplateView):
 
     def get(self, request, place_slug, category_slug):
         postcodes = Postcode.objects.exclude(place_name=None)
-        if postcodes.filter(slug=place_slug).exists() and Category.objects.filter(slug=category_slug):
-            self.postcode = postcodes.get(slug=place_slug)
-            self.category = Category.objects.get(slug=category_slug)
+        processed_place_slug = place_slug.lower().strip()
+        processed_category_slug = category_slug.lower().strip()
+        if postcodes.filter(slug=processed_place_slug).exists() and Category.objects.filter(slug=processed_category_slug):
+            self.postcode = postcodes.get(slug=processed_place_slug)
+            self.category = Category.objects.get(slug=processed_category_slug)
             self.radius = 10000
             return self.define_object_list_return_response()
         else:

--- a/aliss/views/places.py
+++ b/aliss/views/places.py
@@ -76,14 +76,16 @@ class PlaceView(TemplateView):
         return context
 
     def get(self, request, place_slug):
-        self.postcode = get_object_or_404(Postcode, slug=place_slug)
-        content_slug = "places" + "-" + place_slug
+        processed_slug = place_slug.lower().strip().replace(' ', '+')
+        self.postcode = get_object_or_404(Postcode, slug=processed_slug)
+        processed_postcode = self.postcode.postcode.replace(' ', '+')
+        content_slug = "places" + "-" + processed_slug
         if ContentBlock.objects.filter(slug=content_slug).exists():
             return self.render_to_response(self.get_context_data())
         else:
             return HttpResponseRedirect(
                 "{url}?postcode={postcode}".format(
                     url=reverse('search'),
-                    postcode=self.postcode.postcode,
+                    postcode=processed_postcode,
                 )
             )


### PR DESCRIPTION
## Description
- Noticed that the `places/` route was case sensitive for both the `placename` and `category`

- Wrote tests to check that mixed case searches could be completed. 

- Added methods to process the slugs before completing searches. 

## Related Issue/Issues
-https://github.com/Mike-Heneghan/ALISS/issues/106


## Relevant Screenshots 

<img width="838" alt="Screenshot 2019-09-18 at 13 35 38" src="https://user-images.githubusercontent.com/36415632/65149095-667cc000-da19-11e9-834d-218eb66a521f.png">

<img width="743" alt="Screenshot 2019-09-18 at 13 36 08" src="https://user-images.githubusercontent.com/36415632/65149102-6977b080-da19-11e9-967a-bb1dfc49b197.png">

<img width="1099" alt="Screenshot 2019-09-18 at 13 36 51" src="https://user-images.githubusercontent.com/36415632/65149110-6bda0a80-da19-11e9-83cf-e2617558b5ce.png">

## Testing
- Added additional tests with requests with uppercase params.

## Follow Up
- [ ] Feedback on solution. 
