### PR TITLE
Enhance/toggle accessibility

### DIFF
--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -269,12 +269,26 @@ $(document).ready(() => {
     var id = $thisToggle.attr('id');
     $(`#${id}_toggle`).attr('tabindex', '0');
     $(`#${id}_toggle`).attr('role', 'button');
+    $(`#${id}_toggle`).attr('aria-expanded', false);
     $(`#${id}_toggle`).click(function() {
       $(`#${id}`).toggleClass('active');
       $(this).toggleClass('active');
+      if ($(this).hasClass('active')){
+        $(`#${id}_toggle`).attr('aria-expanded', true);
+      }
+      else {
+        $(`#${id}_toggle`).attr('aria-expanded', false);
+      }
     }).keypress(function() {
       $(`#${id}`).toggleClass('active');
       $(this).toggleClass('active');
+      $(this).toggleClass('active');
+      if ($(this).hasClass('active')){
+        $(`#${id}_toggle`).attr('aria-expanded', true);
+      }
+      else {
+        $(`#${id}_toggle`).attr('aria-expanded', false);
+      }
     });
   });
 

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -268,8 +268,9 @@ $(document).ready(() => {
     var $thisToggle = $(this);
     var id = $thisToggle.attr('id');
     $(`#${id}_toggle`).attr('tabindex', '0');
-    $(`#${id}_toggle`).attr('role', 'button');
+    // $(`#${id}_toggle`).attr('role', 'button');
     $(`#${id}_toggle`).attr('aria-expanded', false);
+    $(`#${id}_toggle`).attr('aria-controls', `#${id}`);
     $(`#${id}_toggle`).click(function() {
       $(`#${id}`).toggleClass('active');
       $(this).toggleClass('active');
@@ -281,7 +282,6 @@ $(document).ready(() => {
       }
     }).keypress(function() {
       $(`#${id}`).toggleClass('active');
-      $(this).toggleClass('active');
       $(this).toggleClass('active');
       if ($(this).hasClass('active')){
         $(`#${id}_toggle`).attr('aria-expanded', true);

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -268,6 +268,7 @@ $(document).ready(() => {
     var $thisToggle = $(this);
     var id = $thisToggle.attr('id');
     $(`#${id}_toggle`).attr('tabindex', '0');
+    $(`#${id}_toggle`).attr('role', 'button');
     $(`#${id}_toggle`).click(function() {
       $(`#${id}`).toggleClass('active');
       $(this).toggleClass('active');

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -267,6 +267,7 @@ $(document).ready(() => {
   $('.toggled').each(function(index, el) {
     var $thisToggle = $(this);
     var id = $thisToggle.attr('id');
+    $(`#${id}_toggle`).attr('tabindex', '0');
     $(`#${id}_toggle`).click(function() {
       $(`#${id}`).toggleClass('active');
       $(this).toggleClass('active');

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -268,7 +268,7 @@ $(document).ready(() => {
     var $thisToggle = $(this);
     var id = $thisToggle.attr('id');
     $(`#${id}_toggle`).attr('tabindex', '0');
-    // $(`#${id}_toggle`).attr('role', 'button');
+    $(`#${id}_toggle`).attr('role', 'button');
     $(`#${id}_toggle`).attr('aria-expanded', false);
     $(`#${id}_toggle`).attr('aria-controls', `#${id}`);
     $(`#${id}_toggle`).click(function() {
@@ -276,6 +276,7 @@ $(document).ready(() => {
       $(this).toggleClass('active');
       if ($(this).hasClass('active')){
         $(`#${id}_toggle`).attr('aria-expanded', true);
+
       }
       else {
         $(`#${id}_toggle`).attr('aria-expanded', false);


### PR DESCRIPTION
## Description
- Currently, for keyboard-only and screen reader users the toggles we have on the site are challenging. 

- They are not keyboard navigatable and even it simply made so do not give non-visual feedback of any change. 

- Added JS to give clearer aria attributes site-wide toggles.

## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/107
- https://github.com/Mike-Heneghan/ALISS/issues/108
- https://github.com/Mike-Heneghan/ALISS/issues/110
- https://github.com/Mike-Heneghan/ALISS/issues/112

## Relevant Screenshots 

<img width="442" alt="Screenshot 2019-10-03 at 11 25 59" src="https://user-images.githubusercontent.com/36415632/66119462-9f4b9600-e5d0-11e9-9990-91cf33c06e59.png">

## Testing
- As this is a JS focused solution there were no automated tests added.
- Did test the screen reader functionality using macOS "Voice Over" as a screen reader novice.

## Follow Up
- [ ] Might need to run gulp to update the static JS.
- [ ] Potential opportunity to refactor.
