### PR TITLE
Enhance/review org elasticsearch

### DIFF
--- a/aliss/search.py
+++ b/aliss/search.py
@@ -233,7 +233,6 @@ def filter_organisations_by_query(queryset, q):
                 {
                     "multi_match": {
                         "query": q, "type": "most_fields",
-                        "operator": "and",
                         "fields":["name^2", "description"],
                         "fuzziness": "AUTO:4,7"
                     }
@@ -242,7 +241,7 @@ def filter_organisations_by_query(queryset, q):
                 {
                     "multi_match": {
                         "query": q, "type": "most_fields",
-                        "operator": "or",
+                        "operator": "and",
                         "fields": ["name^2", "description^1.5"],
                     }
                 }

--- a/aliss/tests/models/test_organisation.py
+++ b/aliss/tests/models/test_organisation.py
@@ -102,12 +102,17 @@ class OrganisationTestCase(TestCase):
         self.assertEqual(result_all[0].name, unpublished_org.name)
         self.assertEqual(result_published[0].name, published_org.name)
 
-    def test_fuzziness_of_organisation_search(self):
+    def test_specificity_of_organisation_search(self):
         queryset = Fixtures.es_organisation_connection()
         exact_query = "Scottish Optometrist Society"
         inexact_query = "Scottish Optometrist Society Glasgow"
+        undesired_query = "Scottish Ontology Society"
         result_exact_query = filter_organisations_by_query(queryset, exact_query).execute()
         result_inexact_query = filter_organisations_by_query(queryset, inexact_query).execute()
+        result_undesired_query = filter_organisations_by_query(queryset, undesired_query).execute()
+        print(result_exact_query[0].meta.score)
+        print(result_inexact_query[0].meta.score)
+        print(result_undesired_query[0].meta.score)
         print(inexact_query)
         while len(result_inexact_query) == 0:
             inexact_query = inexact_query[:-1]
@@ -116,6 +121,7 @@ class OrganisationTestCase(TestCase):
         print("Successful query: ", inexact_query)
         self.assertEqual(result_exact_query[0].name, self.org2.name)
         self.assertEqual(result_inexact_query[0].name, self.org2.name)
+        self.assertEqual(result_undesired_query[0].name, self.org2.name)
 
     def tearDown(self):
         for service in Service.objects.filter(name="My First Service"):
@@ -133,4 +139,6 @@ class OrganisationTestCase(TestCase):
         for organisation in Organisation.objects.filter(name="Banana Unpublished"):
             organisation.delete()
         for organisation in Organisation.objects.filter(name="Banana Published"):
+            organisation.delete()
+        for organisation in Organisation.objects.filter(name="Scottish Optometrist Society"):
             organisation.delete()

--- a/aliss/tests/models/test_organisation.py
+++ b/aliss/tests/models/test_organisation.py
@@ -112,7 +112,6 @@ class OrganisationTestCase(TestCase):
         result_undesired_query = filter_organisations_by_query(queryset, undesired_query).execute()
         while len(result_inexact_query) == 0:
             inexact_query = inexact_query[:-1]
-            print(inexact_query)
             result_inexact_query = filter_organisations_by_query(queryset, inexact_query).execute()
         self.assertEqual(result_exact_query[0].name, self.org2.name)
         self.assertEqual(result_inexact_query[0].name, self.org2.name)

--- a/aliss/tests/models/test_organisation.py
+++ b/aliss/tests/models/test_organisation.py
@@ -110,15 +110,10 @@ class OrganisationTestCase(TestCase):
         result_exact_query = filter_organisations_by_query(queryset, exact_query).execute()
         result_inexact_query = filter_organisations_by_query(queryset, inexact_query).execute()
         result_undesired_query = filter_organisations_by_query(queryset, undesired_query).execute()
-        print(result_exact_query[0].meta.score)
-        print(result_inexact_query[0].meta.score)
-        print(result_undesired_query[0].meta.score)
-        print(inexact_query)
         while len(result_inexact_query) == 0:
             inexact_query = inexact_query[:-1]
             print(inexact_query)
             result_inexact_query = filter_organisations_by_query(queryset, inexact_query).execute()
-        print("Successful query: ", inexact_query)
         self.assertEqual(result_exact_query[0].name, self.org2.name)
         self.assertEqual(result_inexact_query[0].name, self.org2.name)
         self.assertEqual(result_undesired_query[0].name, self.org2.name)

--- a/aliss/tests/test_search.py
+++ b/aliss/tests/test_search.py
@@ -118,3 +118,5 @@ class SearchTestCase(TestCase):
         Fixtures.organisation_teardown()
         for organisation in Organisation.objects.filter(name="Test0rg"):
             organisation.delete()
+        for organisation in Organisation.objects.filter(name="Another org"):
+            organisation.delete()


### PR DESCRIPTION
## Description
- At the moment when searching for organisations if a user adds an extra keyword beyond the name for example then no results are shown. 

- This is due to the "and" operator in the "must" section of the elastic search `filter_organisations_by_query` method.

- Additionally added an "and" operator to the 'should' section give higher scores for closer matches. 

- The result of this change is a more permissive search although it might need to be tested with a larger data set than what is currently available to me. 

## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/109

## Testing
- Added test that close but verbose query terms return the expected results. 
 
## Follow Up
- [ ] Might need to test the feature with a bigger data set and devise more test cases.  
