### PR TITLE
Enhance/modal accessibility

### DIFF
--- a/aliss/templates/account/list.html
+++ b/aliss/templates/account/list.html
@@ -60,7 +60,7 @@
     <div class="modal" id="user-{{user.pk}}">
     <div class="pad">
       <div class="heading">
-        <a class="close alert icon-link">
+        <a id="user-{{user.pk}}_modal_close" role="button" tabindex="0" class="close alert icon-link">
           <span class="icon">
             <i class="fas fa-times"></i>
           </span>

--- a/aliss/templates/account/my_recommendations.html
+++ b/aliss/templates/account/my_recommendations.html
@@ -14,7 +14,7 @@
                     <div class="modal" id="email_list_{{ recommendation_list.pk }}">
                         <div class="pad">
                             <div class="heading">
-                                <a class="close alert icon-link">
+                                <a role="button" id="email_recommendation_modal_close" tabindex="0" class="close alert icon-link">
                                     <span class="icon">
                                         <i class="fas fa-times"></i>
                                     </span>
@@ -53,7 +53,7 @@
                         <div class="modal" id="delete_recommendation_list_{{ recommendation_list.pk }}">
                             <div class="pad">
                                 <div class="heading">
-                                    <a class="close alert icon-link">
+                                    <a role="button" id="delete_recommendation_list_close" tabindex="0" class="close alert icon-link">
                                         <span class="icon">
                                             <i class="fas fa-times"></i>
                                         </span>
@@ -67,7 +67,7 @@
                                         <form method="post" action="{% url 'account_my_recommendations_delete' pk=recommendation_list.pk %}">
                                             {% csrf_token %}
                                             <input type="submit" class="button alert" value="Delete">
-                                            <a class="button secondary cancel">Cancel</a>
+                                            <a role="button" tabindex="0" id="delete_recommendation_list_cancel" class="button secondary cancel">Cancel</a>
                                         </form>
                                     </div>
                                 </div>

--- a/aliss/templates/account/recommendation_list.html
+++ b/aliss/templates/account/recommendation_list.html
@@ -5,7 +5,7 @@
   <div class="modal" id="email_list">
     <div class="pad">
       <div class="heading">
-        <a class="close alert icon-link">
+        <a role="button" id="email_list_modal_close" tabindex="0" class="close alert icon-link">
           <span class="icon">
             <i class="fas fa-times"></i>
           </span>

--- a/aliss/templates/account/recommendation_list.html
+++ b/aliss/templates/account/recommendation_list.html
@@ -79,7 +79,7 @@
           {% endfor %}
         </ul>
         <div class="actions">
-          <a id="email_list_modal" class="icon-link">
+          <a id="email_list_modal" role="button" tabindex="0" class="icon-link">
             <span class="icon">
               <i class="fas fa-envelope"></i>
             </span>

--- a/aliss/templates/organisation/create.html
+++ b/aliss/templates/organisation/create.html
@@ -6,7 +6,7 @@
 <div class="modal" id="data_standard_agreement">
   <div class="pad">
     <div class="heading">
-      <a id="data_standard_close" class="close alert icon-link">
+      <a id="data_standard_close" role="button" tabindex="0" class="close alert icon-link">
         <span class="icon">
           <i class="fas fa-times"></i>
         </span>
@@ -32,8 +32,8 @@
     </div>
     <div class="buttons">
       <form>
-        <a id="data_standard_accept" class="button secondary alert close">Accept</a>
-        <a id="data_standard_decline" class="button secondary cancel">Decline</a>
+        <a id="data_standard_accept" role="button" tabindex="0"  class="button secondary alert close">Accept</a>
+        <a id="data_standard_decline" role="button" tabindex="0" class="button secondary cancel">Decline</a>
       </form>
     </div>
   </div>

--- a/aliss/templates/organisation/detail.html
+++ b/aliss/templates/organisation/detail.html
@@ -21,7 +21,7 @@
 <div class="modal" id="delete_org">
   <div class="pad">
     <div class="heading">
-      <a class="close alert icon-link">
+      <a id="delete_organisation_modal_close" role="button" tabindex="0" class="close alert icon-link">
         <span class="icon">
           <i class="fas fa-times"></i>
         </span>
@@ -36,7 +36,7 @@
         <form method="post" action="{% url 'organisation_delete' pk=object.pk %}">
           {% csrf_token %}
           <input type="submit" class="button alert" value="Delete">
-          <a class="button secondary cancel">Cancel</a>
+          <a id="delete_organisation_modal_cancel" role="button" tabindex="0" class="button secondary cancel">Cancel</a>
         </form>
       </div>
     </div>

--- a/aliss/templates/service/detail.html
+++ b/aliss/templates/service/detail.html
@@ -21,7 +21,7 @@
 <div class="modal" id="improve-listing">
   <div class="pad">
     <div class="heading">
-      <a class="close alert icon-link">
+      <a id="improve_listing_modal_close" href="#" tabindex="0" class="close alert icon-link">
         <span class="icon">
           <i class="fas fa-times"></i>
         </span>

--- a/aliss/templates/service/detail.html
+++ b/aliss/templates/service/detail.html
@@ -21,7 +21,7 @@
 <div class="modal" id="improve-listing">
   <div class="pad">
     <div class="heading">
-      <a id="improve_listing_modal_close" href="#" tabindex="0" class="close alert icon-link">
+      <a id="improve_listing_modal_close" tabindex="0" role="button" class="close alert icon-link">
         <span class="icon">
           <i class="fas fa-times"></i>
         </span>
@@ -43,7 +43,7 @@
 <div class="modal" id="delete_service">
   <div class="pad">
     <div class="heading">
-      <a class="close alert icon-link">
+      <a id="delete_service_modal_close" tabindex="0" role="button" class="close alert icon-link">
         <span class="icon">
           <i class="fas fa-times"></i>
         </span>
@@ -57,7 +57,7 @@
         <form method="post" action="{% url 'service_delete' pk=object.pk %}">
           {% csrf_token %}
           <input type="submit" class="button alert" value="Delete">
-          <a class="button secondary cancel">Cancel</a>
+          <a role="button" id="delete_service_cancel" tabindex="0" class="button secondary cancel">Cancel</a>
         </form>
       </div>
     </div>
@@ -67,7 +67,7 @@
 <div class="modal" id="add_list">
   <div class="pad">
     <div class="heading">
-      <a class="close alert icon-link">
+      <a id="add_list_modal_close" role="button" tabindex="0" class="close alert icon-link">
         <span class="icon">
           <i class="fas fa-times"></i>
         </span>
@@ -90,7 +90,7 @@
 <div class="modal" id="iframe_generator">
   <div class="pad">
     <div class="heading">
-      <a class="close alert icon-link">
+      <a role="button" id="iframe_generator_modal_close" tabindex="0" class="close alert icon-link">
         <span class="icon">
           <i class="fas fa-times"></i>
         </span>
@@ -100,10 +100,10 @@
     </div>
     <div class="form">
       <form  action="/">
-        <textarea id="embedded_code" onclick="this.focus();this.select()" readonly="readonly"><iframe src="{% absolute_url 'service_detail_map' pk=object.pk %}" width="500" height="500" frameborder="0"></iframe><p><a href="{% absolute_url 'service_detail' pk=object.pk %}">Explore this service on ALISS</a></p>
+        <textarea tabindex="0" id="embedded_code" onclick="this.focus();this.select()" readonly="readonly"><iframe src="{% absolute_url 'service_detail_map' pk=object.pk %}" width="500" height="500" frameborder="0"></iframe><p><a href="{% absolute_url 'service_detail' pk=object.pk %}">Explore this service on ALISS</a></p>
         </textarea>
       </form>
-      <a id="copy_to_clipboard" class="button secondary-class">Copy to clipboard</a>
+      <a id="copy_to_clipboard" role="button" tabindex="0" class="button secondary-class">Copy to clipboard</a>
       <p id="copy_message" class="small"></p>
       <p>The map will be embedded at 500 x 500 (px)</p>
       <p>This embedded map will include a link to the ALISS page for this service.</p>

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -297,14 +297,6 @@ $(document).ready(() => {
         $('.black').toggleClass('show');
         $(`#${id}`).attr('tabindex', '0');
         $(`#${id}`).focus();
-        var hideNotTabableAttrs = {
-          'aria-hidden': 'true',
-          'tabindex': '-1',
-        };
-        $("body > *").not("body > " + `#${id}`).attr(...hideNotTabableAttrs);
-
-
-
       }
     // Adding modal on keypress behaviour
     }).keypress(function(e){
@@ -314,11 +306,6 @@ $(document).ready(() => {
         $('.black').toggleClass('show');
         $(`#${id}`).attr('tabindex', '0');
         $(`#${id}`).focus();
-        var hideNotTabableAttrs = {
-          'aria-hidden': 'true',
-          'tabindex': '-1',
-        };
-        $("body > *").not("body > " + "#" +`${id}`).attr(...hideNotTabableAttrs);
       }
     });
   });

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -308,7 +308,6 @@ $(document).ready(() => {
       if ($('#' + `${modalId}`).hasClass('active')){
 
         if (e.key == "Tab" && !e.shiftKey){
-          console.log("Tabbed")
           handleForwardTab();
         }
         if (e.key == "Tab" && e.shiftKey) {
@@ -319,7 +318,7 @@ $(document).ready(() => {
           $('.modal').removeClass('active');
         }
       }
-    })
+    });
   }
 
   // Modals

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -279,7 +279,7 @@ $(document).ready(() => {
   //Handle modal keyboard trap
   function checkKeyPress(modalId){
 
-    // Setup variables for the focusable elments of the modal 
+    // Setup variables for the focusable elments of the modal
     var focusableElements = $('#' + `${modalId}`).find("a, a[role='button'] [tabindex='0'], input, button, textarea").not("input[type='hidden']");
     var focusableLength = focusableElements.length;
     var finalIndex = (focusableLength - 1);
@@ -336,7 +336,7 @@ $(document).ready(() => {
     $('#' + `${id}` + '_modal').attr('role', 'button');
     $('#' + `${id}` + '_modal').attr('tabindex', '0');
 
-    //  Adding modal click behaviour
+    // Adding modal click behaviour
     $(`#${id}_modal, a[data-modal="${id}"], input[data-modal="${id}"]`).click(function(e){
       if ($(this).is(':checkbox') && !e.target.checked){
       } else {

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -276,6 +276,50 @@ $(document).ready(() => {
     });
   });
 
+  //Handle modal keyboard trap
+  function checkKeyPress(modalId){
+
+    var focusableElements = $('#' + `${modalId}`).find("a, [tabindex='0'], input").not("input[type='hidden']");
+
+    var focusableLength = focusableElements.length;
+    var finalIndex = (focusableLength - 1);
+
+    var firstFocusable = focusableElements[0];
+    var lastFocusable = focusableElements[finalIndex];
+
+    if ($(`#${modalId}`).hasClass('active')){
+      firstFocusable.focus();
+    }
+
+    $('body').keydown(function(e){
+
+      function handleBackwardTab() {
+        if (document.activeElement === firstFocusable) {
+          e.preventDefault();
+          lastFocusable.focus();
+        }
+      }
+
+      function handleForwardTab() {
+        if (document.activeElement === lastFocusable) {
+          e.preventDefault();
+          firstFocusable.focus();
+        }
+      }
+
+      if ($('#' + `${modalId}`).hasClass('active')){
+
+        if (e.key == "Tab" && !e.shiftKey){
+          console.log("Tabbed")
+          handleForwardTab();
+        }
+        if (e.key == "Tab" && e.shiftKey) {
+          handleBackwardTab();
+        }
+      }
+    })
+  }
+
   // Modals
   $('.modal').each(function(index, el) {
     var $thisModal = $(this);
@@ -295,8 +339,7 @@ $(document).ready(() => {
       } else {
         $(`#${id}`).toggleClass('active');
         $('.black').toggleClass('show');
-        $(`#${id}`).attr('tabindex', '0');
-        $(`#${id}`).focus();
+        checkKeyPress(id);
       }
     // Adding modal on keypress behaviour
     }).keypress(function(e){
@@ -304,8 +347,7 @@ $(document).ready(() => {
       } else {
         $(`#${id}`).toggleClass('active');
         $('.black').toggleClass('show');
-        $(`#${id}`).attr('tabindex', '0');
-        $(`#${id}`).focus();
+        checkKeyPress(id);
       }
     });
   });

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -280,7 +280,16 @@ $(document).ready(() => {
   $('.modal').each(function(index, el) {
     var $thisToggle = $(this);
     var id = $thisToggle.attr('id');
+    console.log(id);
+    $('#' + `${id}` + '_modal').attr('role', 'button');
+    $('#' + `${id}` + '_modal').attr('tabindex', '0');
     $(`#${id}_modal, a[data-modal="${id}"], input[data-modal="${id}"]`).click(function(e){
+      if ($(this).is(':checkbox') && !e.target.checked){
+      } else {
+        $(`#${id}`).toggleClass('active');
+        $('.black').toggleClass('show');
+      }
+    }).keypress(function(e){
       if ($(this).is(':checkbox') && !e.target.checked){
       } else {
         $(`#${id}`).toggleClass('active');
@@ -294,6 +303,9 @@ $(document).ready(() => {
     $('.modal').removeClass('active');
   });
   $('.modal a.close, .modal a.cancel').click(function() {
+    $('.black').removeClass('show');
+    $('.modal').removeClass('active');
+  }).keypress(function() {
     $('.black').removeClass('show');
     $('.modal').removeClass('active');
   });

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -281,6 +281,10 @@ $(document).ready(() => {
     var $thisModal = $(this);
     var id = $thisModal.attr('id');
 
+    // Updating modal attributes
+    $(this).attr('role', 'dialog');
+    $(this).attr('aria-modal', 'true');
+
     // Updating modal links
     $('#' + `${id}` + '_modal').attr('role', 'button');
     $('#' + `${id}` + '_modal').attr('tabindex', '0');
@@ -291,12 +295,30 @@ $(document).ready(() => {
       } else {
         $(`#${id}`).toggleClass('active');
         $('.black').toggleClass('show');
+        $(`#${id}`).attr('tabindex', '0');
+        $(`#${id}`).focus();
+        var hideNotTabableAttrs = {
+          'aria-hidden': 'true',
+          'tabindex': '-1',
+        };
+        $("body > *").not("body > " + `#${id}`).attr(...hideNotTabableAttrs);
+
+
+
       }
+    // Adding modal on keypress behaviour
     }).keypress(function(e){
       if ($(this).is(':checkbox') && !e.target.checked){
       } else {
         $(`#${id}`).toggleClass('active');
         $('.black').toggleClass('show');
+        $(`#${id}`).attr('tabindex', '0');
+        $(`#${id}`).focus();
+        var hideNotTabableAttrs = {
+          'aria-hidden': 'true',
+          'tabindex': '-1',
+        };
+        $("body > *").not("body > " + "#" +`${id}`).attr(...hideNotTabableAttrs);
       }
     });
   });

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -278,11 +278,14 @@ $(document).ready(() => {
 
   // Modals
   $('.modal').each(function(index, el) {
-    var $thisToggle = $(this);
-    var id = $thisToggle.attr('id');
-    console.log(id);
+    var $thisModal = $(this);
+    var id = $thisModal.attr('id');
+
+    // Updating modal links
     $('#' + `${id}` + '_modal').attr('role', 'button');
     $('#' + `${id}` + '_modal').attr('tabindex', '0');
+
+    //  Adding modal click behaviour
     $(`#${id}_modal, a[data-modal="${id}"], input[data-modal="${id}"]`).click(function(e){
       if ($(this).is(':checkbox') && !e.target.checked){
       } else {

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -354,17 +354,30 @@ $(document).ready(() => {
     });
   });
 
+  // Find the active modal and get it's id before closing it and returning focus to the element that launched it.
+  function closeModalFocusOnLastClicked(){
+    $('.black').removeClass('show');
+    let id = ''
+    $('.modal').each(function(index, el) {
+      if ($(el).hasClass('active')){
+        id = $(el).attr('id')
+      }
+    })
+    $('.modal').removeClass('active');
+    $(`#${id}_modal`).focus();
+  }
+  // Allow users to click on black modal surround to close it and shift focus to last selected.
   $('.black').click(function() {
-    $(this).removeClass('show');
-    $('.modal').removeClass('active');
+    closeModalFocusOnLastClicked()
   });
+
+  // Add on click listener to cancel and close modal buttons to hide modal and return focus to last element.
   $('.modal a.close, .modal a.cancel').click(function() {
-    $('.black').removeClass('show');
-    $('.modal').removeClass('active');
+    closeModalFocusOnLastClicked()
   }).keypress(function() {
-    $('.black').removeClass('show');
-    $('.modal').removeClass('active');
+    closeModalFocusOnLastClicked()
   });
+
 
   // Results Areas Toggle
   $('.service-areas a').click(function() {

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -316,6 +316,7 @@ $(document).ready(() => {
         if (e.key == "Escape") {
           $('.black').removeClass('show');
           $('.modal').removeClass('active');
+          $(`#${modalId}_modal`).focus();
         }
       }
     });

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -279,11 +279,9 @@ $(document).ready(() => {
   //Handle modal keyboard trap
   function checkKeyPress(modalId){
 
-    var focusableElements = $('#' + `${modalId}`).find("a, [tabindex='0'], input").not("input[type='hidden']");
-
+    var focusableElements = $('#' + `${modalId}`).find("a, a[role='button'] [tabindex='0'], input, button, textarea").not("input[type='hidden']");
     var focusableLength = focusableElements.length;
     var finalIndex = (focusableLength - 1);
-
     var firstFocusable = focusableElements[0];
     var lastFocusable = focusableElements[finalIndex];
 
@@ -315,6 +313,10 @@ $(document).ready(() => {
         }
         if (e.key == "Tab" && e.shiftKey) {
           handleBackwardTab();
+        }
+        if (e.key == "Escape") {
+          $('.black').removeClass('show');
+          $('.modal').removeClass('active');
         }
       }
     })

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -279,6 +279,7 @@ $(document).ready(() => {
   //Handle modal keyboard trap
   function checkKeyPress(modalId){
 
+    // Setup variables for the focusable elments of the modal 
     var focusableElements = $('#' + `${modalId}`).find("a, a[role='button'] [tabindex='0'], input, button, textarea").not("input[type='hidden']");
     var focusableLength = focusableElements.length;
     var finalIndex = (focusableLength - 1);
@@ -304,7 +305,7 @@ $(document).ready(() => {
           firstFocusable.focus();
         }
       }
-
+      // Setup keypress listeners to avoid user tabbing off of modal
       if ($('#' + `${modalId}`).hasClass('active')){
 
         if (e.key == "Tab" && !e.shiftKey){
@@ -357,25 +358,25 @@ $(document).ready(() => {
   // Find the active modal and get it's id before closing it and returning focus to the element that launched it.
   function closeModalFocusOnLastClicked(){
     $('.black').removeClass('show');
-    let id = ''
+    let id = '';
     $('.modal').each(function(index, el) {
       if ($(el).hasClass('active')){
-        id = $(el).attr('id')
+        id = $(el).attr('id');
       }
-    })
+    });
     $('.modal').removeClass('active');
     $(`#${id}_modal`).focus();
   }
   // Allow users to click on black modal surround to close it and shift focus to last selected.
   $('.black').click(function() {
-    closeModalFocusOnLastClicked()
+    closeModalFocusOnLastClicked();
   });
 
   // Add on click listener to cancel and close modal buttons to hide modal and return focus to last element.
   $('.modal a.close, .modal a.cancel').click(function() {
-    closeModalFocusOnLastClicked()
+    closeModalFocusOnLastClicked();
   }).keypress(function() {
-    closeModalFocusOnLastClicked()
+    closeModalFocusOnLastClicked();
   });
 
 


### PR DESCRIPTION
## Description
- Currently, modals on the website are challenging to use for keyboard-only users and potentially impossible for screen reader users. 

- Many of the modals could not be triggered with the keyboard alone and if launched would not draw focus and hence would be hard to navigate and interact with. 

- Using suggestions from accessibility guidelines the HTML markup was updated as well as the JS to make modals more usable. 

-Although there are still opportunities for the modals to be improved the changes suggested should allow users to interact with the dynamic content and ease the process of using ALISS.


## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/107
- https://github.com/Mike-Heneghan/ALISS/issues/108
- https://github.com/Mike-Heneghan/ALISS/issues/111


## Relevant Screenshots 
First item in modal is focusable:
<img width="572" alt="Screenshot 2019-10-10 at 13 56 44" src="https://user-images.githubusercontent.com/36415632/66570644-e8b65b00-eb65-11e9-81ee-4fe28c9264e5.png">

On closing modal focus return to the element that launched it.
<img width="490" alt="Screenshot 2019-10-10 at 13 56 56" src="https://user-images.githubusercontent.com/36415632/66570648-ece27880-eb65-11e9-9c97-52f30e633ef2.png">

## Testing
- As the changes were in relation to the JS and updating IDs on modals in HTML automated tests were not created for this feature. 
- Manual testing was done using macOS VoiceOver and navigating with keyboard only.

## Follow Up
- [ ] May need to run gulp to recompile static files.
- [ ] Might be worth testing this feature further and looking for other improvements.
