### PR TITLE
Bug/email service error

### DIFF
--- a/aliss/tests/forms/test_service_email.py
+++ b/aliss/tests/forms/test_service_email.py
@@ -1,0 +1,35 @@
+from django.test import TestCase, RequestFactory
+from django.urls import reverse
+from aliss.models import *
+from aliss.forms import ServiceEmailForm
+from aliss.tests.fixtures import Fixtures
+
+class ServiceEmailFormTestCase(TestCase):
+    fixtures = ['categories.json']
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        t,u,c,_ = Fixtures.create_users()
+        self.org = Fixtures.create_organisation(t, u, c)
+        self.service = Service.objects.create(name="My First Service", description="A handy service", organisation=self.org, created_by=t, updated_by=u)
+
+    def test_form_is_valid_valid_email(self):
+        request = self.factory.post(reverse('service_email'), { 'email': 'test@test.com', 'service': self.service.pk })
+        form = ServiceEmailForm(request.POST)
+        self.assertEqual(form.is_valid(), True)
+
+    def test_form_is_invalid_invalid_email(self):
+        request = self.factory.post(reverse('service_email'), { 'email': 'test@test', 'service': self.service.pk })
+        form = ServiceEmailForm(request.POST)
+        self.assertEqual(form.is_valid(), False)
+
+    def test_form_is_invalid_blank_email(self):
+        request = self.factory.post(reverse('service_email'), { 'email': '', 'service': self.service.pk })
+        form = ServiceEmailForm(request.POST)
+        self.assertEqual(form.is_valid(), False)
+
+    def tearDown(self):
+        for service in Service.objects.filter(name="My First Service"):
+            service.delete()
+        for organisation in Organisation.objects.filter(name="TestOrg"):
+            organisation.delete()

--- a/aliss/views/service.py
+++ b/aliss/views/service.py
@@ -322,6 +322,12 @@ class ServiceEmailView(SuccessMessageMixin, FormView):
 
         return super(ServiceEmailView, self).form_valid(form)
 
+    def form_invalid(self, form):
+        self.service = form.cleaned_data.get('service')
+        error_message = "Submitted email not valid, please try again."
+        messages.warning(self.request, error_message)
+        failure_url = reverse('service_detail', kwargs={'pk': self.service.pk})
+        return HttpResponseRedirect(failure_url)
 
 class ServiceAtLocationDelete(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
     success_message = "Location successfully removed from service."


### PR DESCRIPTION
## Description
- Investigated a 500 error which related to the `services/email` route.

- Found that when a user submits a blank email field or an invalid email into the 'Email this listing"  form on the Service detail page the page crashes. 

- It was noted that the service email form has a `form_valid` method which is triggered when a valid email is submitted and redirects back to the service detail page.

- If the email is invalid then this method is not called and it would appear there is an attempt to render the route and a template is not found.

- Added a `form_invalid` to the view to handle these occasions which redirects to the service detail with a message that "Submitted email not valid, please try again.". This solution is similar to success but with a different message.

- Ideally, a warning would appear at the field although I had issues trying to implement this. With this solution, the site does not crash. The user is redirected to the page they were on with a message to hopefully catch that they have made an error.


## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/117


## Relevant Screenshots 
<img width="438" alt="Screenshot 2019-10-25 at 12 11 20" src="https://user-images.githubusercontent.com/36415632/67573178-a24d2880-f72f-11e9-9bcb-ea43654abdeb.png">

<img width="1283" alt="Screenshot 2019-10-25 at 12 11 45" src="https://user-images.githubusercontent.com/36415632/67573186-a5e0af80-f72f-11e9-80ed-181e919a50a6.png">


## Testing
- Added a basic test for the form being valid and invalid depending on submitted values. 

## Follow Up
- [ ] Review proposed changes and discuss a more elegant solution. 
