### PR TITLE
Enhance/services in local authority area

### DIFF
--- a/aliss/management/commands/generate_location_report.py
+++ b/aliss/management/commands/generate_location_report.py
@@ -24,10 +24,6 @@ class Command(BaseCommand):
         # location_objects = Location.objects.all()
         # boundaries_data_mappings = setup_data_set_doubles()
         # locations_in_boundaries(location_objects, boundaries_data_mappings)
-        # print("\n---------- Services in Region by Service Area Atrribute-----------")
-        # services_by_service_area_attribute()
-        # print("\n---------- Services in Region by Location in Service Area-----------")
-        # services_by_location_match_in_service_area()
         print("\n # ---------- Services by Region -----------")
         services_in_service_area = services_in_service_area_regions('local_authority', 2)
         for key, value in services_in_service_area.items():

--- a/aliss/management/commands/generate_location_report.py
+++ b/aliss/management/commands/generate_location_report.py
@@ -18,12 +18,17 @@ class Command(BaseCommand):
         print(options)
         self.verbose = options['verbose']
 
-        print("\n---------- Categories in Service Area -----------")
-        category_in_service_area()
+        # print("\n---------- Categories in Service Area -----------")
+        # category_in_service_area()
         # print("\n---------- Location IDs in Regions -----------")
         # location_objects = Location.objects.all()
         # boundaries_data_mappings = setup_data_set_doubles()
         # locations_in_boundaries(location_objects, boundaries_data_mappings)
+        print("\n---------- Services in Region by Service Area Atrribute-----------")
+        services_by_service_area_attribute()
+        print("\n---------- Services in Region by Location in Service Area-----------")
+        services_by_location_match_in_service_area()
+
 
 
 def postcodes_in_service_area(service_area):
@@ -91,6 +96,38 @@ def locations_in_service_area(location_objects, boundary, verbose=False):
                 print("      " + str(id))
         print("\n")
     return service_area
+
+def services_by_service_area_attribute(service_area='local_authority', type=2):
+    services_by_service_area_region = {}
+    service_area_regions = []
+    service_areas_of_type = ServiceArea.objects.filter(type=2)
+    services_in_service_area_type = Service.objects.filter(service_areas__type=2, locations=None)
+    print("Distinct services without locations in local_authority: ", services_in_service_area_type.distinct().count())
+    for service_area in service_areas_of_type.all():
+        services_in_service_area = services_in_service_area_type.filter(service_areas__name__icontains=service_area.name).all()
+        services_by_service_area_region[service_area.name] = services_in_service_area.distinct().count()
+    for key, value in services_by_service_area_region.items():
+        print(str(key) + ": " + str(value) + "\n")
+
+def services_by_location_match_in_service_area(service_area='local_authority', type=2):
+    services_by_service_area_region = {}
+    service_area_regions = []
+    service_areas_of_type = ServiceArea.objects.filter(type=2)
+    for service_area_region in service_areas_of_type:
+        service_area_regions.append(service_area_region.name)
+    print(service_area_regions)
+    locations_of_services_without_service_area = Location.objects.filter(services__service_areas=None)
+    service_area_mappings = setup_data_set_doubles()
+    boundary = service_area_mappings[service_area]
+    print("Checking for " + service_area + " boundary")
+    service_area_distributions = locations_in_service_area(locations_of_services_without_service_area, boundary)
+    for key, value in service_area_distributions.items():
+        if key in service_area_regions:
+            services_by_service_area_region[key] = Service.objects.filter(locations__in=value).distinct().count()
+    print(services_by_service_area_region)
+
+
+
 
 def locations_in_boundaries(location_objects, boundaries):
     service_areas = {}

--- a/aliss/management/commands/generate_location_report.py
+++ b/aliss/management/commands/generate_location_report.py
@@ -134,9 +134,10 @@ def services_by_location_match_in_service_area(service_area_boundary, type):
 def services_in_service_area_regions(service_area_boundary='local_authority', type=2):
     services_by_service_area_region_service_area_match = services_by_service_area_attribute(type)
     services_by_service_area_region_location_match = services_by_location_match_in_service_area(service_area_boundary, type)
-    merged_services = services_by_service_area_region_service_area_match
-    merged_services.update(services_by_service_area_region_location_match)
+    merged_services = {}
     services_by_service_area = {}
+    for key, value in services_by_service_area_region_location_match.items():
+        merged_services[key] = services_by_service_area_region_service_area_match[key] | value
     service_count = 0
     for key, value in merged_services.items():
         services_by_service_area[key] = value.distinct()


### PR DESCRIPTION
## Description
- For the ALISS team, it would be useful to be able to understand the number of available services in regions defined by service areas and their accompanying boundary data sets. 

- Created queries to count the number of services by service area attribute and location match in boundary data set. 

- These querysets were then combined and deduplicated to ensure the services were not double-counted in a region.

- Added code to state the values found in each search method to allow for sense checking of the validity of the queries.

## Related Issue/Issues
-https://github.com/Mike-Heneghan/ALISS/issues/118

## Testing
- As the data needs to be interpreted it was sense checked rather than having an automatic test added. 

## Follow Up
- [ ] Please review the queries to check for logical errors or inconsistencies. 
