### PR TITLE
Enhance/placename search improvements

### DIFF
--- a/aliss/templates/search/results.html
+++ b/aliss/templates/search/results.html
@@ -24,8 +24,11 @@
     <section id="content" class="results">
       <div class="row title">
         <div class="columns">
-          <h1>Help and support in <span class="postcode">{{ postcode.postcode }}</span>
-          </h1>
+          {% if request.GET.place_name %}
+            <h1>Help and support in <span class="postcode">{{request.GET.place_name}}</span><span class="assigned-categories">({{postcode.postcode}})</h1>
+          {% else %}
+            <h1>Help and support in <span class="postcode">{{ postcode.postcode }}</span></h1>
+          {% endif%}
           <div class="buttons">
             <a href="{% url 'homepage' %}" class="button primary">New search</a>
           </div>

--- a/aliss/tests/views/test_search_view.py
+++ b/aliss/tests/views/test_search_view.py
@@ -219,7 +219,21 @@ class SearchViewTestCase(TestCase):
         self.assertEqual(edinburgh_postcode[0], postcode)
         response = self.client.get('/search/?postcode=edinburgh+')
         self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, '/search/?postcode=EH1+1BQ')
+        self.assertRedirects(response, '/search/?postcode=EH1+1BQ&place_name=Edinburgh')
+
+    def test__valid_placename_search_has_place_in_heading(self):
+        edinburgh_postcode = Postcode.objects.get_or_create(pk="EH1 1BQ", defaults={
+                'postcode': 'EH1 1BQ', 'postcode_district': 'EH1',
+                'postcode_sector': 'EH1 1', 'latitude': 55.95263002,
+                'longitude': -3.19132872, 'council_area_2011_code': 'S12000036',
+                'health_board_area_2014_code': 'S08000024',
+                'integration_authority_2016_code': 'S37000012',
+                'place_name': 'Edinburgh', 'slug': 'edinburgh'
+            }
+        )
+        response = self.client.get('/search/?postcode=EH1+1BQ&place_name=Edinburgh')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<h1>Help and support in <span class=\"postcode\">Edinburgh</span><span class=\"assigned-categories\">(EH1 1BQ)</span></h1>", html=True)
 
     def tearDown(self):
         Fixtures.organisation_teardown()

--- a/aliss/views/search.py
+++ b/aliss/views/search.py
@@ -60,6 +60,7 @@ class SearchView(MultipleObjectMixin, TemplateView):
             searched_term = search_form.data.get('postcode')
             if searched_term:
                 try:
+                    processed_search_term = searched_term.capitalize().strip()
                     lower_searched = searched_term.lower().strip()
                     matched_postcode = Postcode.objects.get(slug=lower_searched).postcode
                     processed_postcode = matched_postcode.upper().strip().replace(' ', '+')
@@ -67,7 +68,7 @@ class SearchView(MultipleObjectMixin, TemplateView):
                         "{url}?postcode={postcode}&place_name={searched_place}".format(
                             url=reverse('search'),
                             postcode=processed_postcode,
-                            searched_place=searched_term,
+                            searched_place=processed_search_term,
                         ))
                 except Postcode.DoesNotExist:
                     invalid_area = search_form.cleaned_data.get('postcode', None) == None

--- a/aliss/views/search.py
+++ b/aliss/views/search.py
@@ -64,9 +64,10 @@ class SearchView(MultipleObjectMixin, TemplateView):
                     matched_postcode = Postcode.objects.get(slug=lower_searched).postcode
                     processed_postcode = matched_postcode.upper().strip().replace(' ', '+')
                     return HttpResponseRedirect(
-                        "{url}?postcode={postcode}".format(
+                        "{url}?postcode={postcode}&place_name={searched_place}".format(
                             url=reverse('search'),
                             postcode=processed_postcode,
+                            searched_place=searched_term,
                         ))
                 except Postcode.DoesNotExist:
                     invalid_area = search_form.cleaned_data.get('postcode', None) == None

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -758,14 +758,14 @@ $(document).ready(() => {
       template: {
         type: "custom",
         method: function(value, item){
-          return "<span class=\"icon\">📍</span>" + value + " (" + item.postcode + ")";
+          return "<span class=\"icon\">📍</span>" + value;
         }
       },
       minCharNumber: 3,
       list: {
         match: { enabled: true },
         onChooseEvent: function(e){
-          var value = $("#postcode").getSelectedItemData().postcode;
+          var value = $("#postcode").getSelectedItemData().place_name;
           $("#postcode").val(value).trigger("change");
         }
       }


### PR DESCRIPTION
## Description
- Some users when searching by place name found the postcodes that appeared in the dropdown confusing. 

<img width="675" alt="Screenshot 2019-10-28 at 17 29 17" src="https://user-images.githubusercontent.com/36415632/68500359-6c419580-0253-11ea-9fcc-7a255a50a720.png">


- Additionally, when they selected an option and the content of the box changed to a postcode this was jarring. 

- Subsequently when the results appear there is not a reference to the terms they searched other than the autocompleted postcode.

 - It was requested that the postcodes would be removed from the dropdown, the autocomplete remaining as the place name and the place name being visible on the results page. 

- Updated the easy autocomplete JS and the search view to handle these changes.

- Now when a user starts typing it autocompletes to the place name it is searched. This fails postcode validation but is found to be a valid place name and the postcode is retrieved and the user redirects to the search results for the appropriate postcode with a keyword argument for `place_name=Glasgow` for example. 

- If the place_name kwarg exists the header has the placename added as per screenshots below.

## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/121

## Relevant Screenshots 
<img width="723" alt="Screenshot 2019-11-08 at 14 47 13" src="https://user-images.githubusercontent.com/36415632/68500046-9777b500-0252-11ea-9db7-8525a3cd8dd2.png">

<img width="656" alt="Screenshot 2019-11-08 at 15 40 31" src="https://user-images.githubusercontent.com/36415632/68500058-9a72a580-0252-11ea-9378-a4dc8b0adb0d.png">

<img width="504" alt="Screenshot 2019-11-08 at 16 43 14" src="https://user-images.githubusercontent.com/36415632/68500077-a199b380-0252-11ea-85f4-a45b324f29a9.png">

<img width="1126" alt="Screenshot 2019-11-08 at 16 43 03" src="https://user-images.githubusercontent.com/36415632/68500082-a65e6780-0252-11ea-923b-bef77a7db65d.png">


## Testing
- Updated an existing test to reflect that the place name search redirects with the new keyword argument `place_name=....` 

- Added a new test to ensure when there is a new place name search the redirected page has the correct title and formatting.

## Follow Up
- [ ] Currently, the `place_name` kwarg is overwritten when some search filters are added as they trigger a page redirect. If the feature is found to be appropriate it might be worth updating to preserve `place_name`.

- [ ] As there are changes to the JS may need to run gulp. 

- [ ] May need to get feedback from the team so might need to deploy to staging and get feedback.

