### PR TITLE
bug organisation logo error

### DIFF
--- a/aliss/forms/organisation.py
+++ b/aliss/forms/organisation.py
@@ -1,5 +1,6 @@
 from itertools import groupby
 from django import forms
+from cloudinary import CloudinaryResource
 from aliss.models import Organisation, Service
 from django.utils.translation import ugettext_lazy as _
 
@@ -35,7 +36,7 @@ class OrganisationForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super(OrganisationForm, self).clean()
         logo = cleaned_data.get("logo")
-        if logo and logo.size < 5000:
+        if (not isinstance(logo, CloudinaryResource)) and logo and logo.size < 5000:
             del cleaned_data['logo']
             raise forms.ValidationError('The image selected for the logo is too small, please use a higher quality image.')
         return cleaned_data

--- a/aliss/templates/organisation/create.html
+++ b/aliss/templates/organisation/create.html
@@ -49,7 +49,7 @@
     </div>
     <div class="grid-x">
       <div class="cell small-12 medium-8 large-8">
-        {% include 'partials/forms/errors.html' with form=form %}
+        <!-- {% include 'partials/forms/errors.html' with form=form %} -->
         {% include 'partials/forms/errors.html' with form=claim_form %}
 
         <form method="post" class="organisation-form" enctype="multipart/form-data">


### PR DESCRIPTION
## Description
- As noticed by ALISS team and server reports identified a bug that when an organisation with a logo was updated `logo.size` was called causing an error.

- When uploading a logo to ensure adequate quality, the file size has to be over 5kb which is checked before the file is converted in a Cloudinary resource. 

- After being saved if the organisation was updated the entire form is resubmitted and hence the validation method would be called again although was no longer relevant as the data structure had changed. 

- After investigating realised the relatively simple solution was to ensure the logo is not a `CloudinaryResource` before calling `.size`.

- After resolving the bug also checked that the validation for file sizes below 5kb still works.

- On creating a service realised the file size validation error was appearing twice as it was being returned automatically from the form as well as manually in the template. If removed from the form the update would not show the error. 

- Hence Commented out the unnecessary call to display in the template to resolve this.

## Screenshots

<img width="793" alt="Screenshot 2019-11-22 at 14 31 34" src="https://user-images.githubusercontent.com/36415632/69436215-d456a800-0d38-11ea-8c9f-d4378e7ab595.png">

## Testing

- As this involves Cloudinary it would be more complex to set up a test case.

- The fix was tested manually by attempting to update valid and invalid images sizes and ensuring that the existing functionality such as remove logo still works when updating organisations. 

- Tested the create page and realised the error messages were being displayed in the form automatically as well as manually on the create.html template so remove the unnecessary call to display the errors. 

## Follow Up
- [ ] Test on staging.
