### PR TITLE
Updated the claim admin view to focus on organisations.

### DIFF
--- a/aliss/admin/claim.py
+++ b/aliss/admin/claim.py
@@ -4,5 +4,5 @@ from aliss.models import Claim
 @admin.register(Claim)
 class ClaimAdmin(admin.ModelAdmin):
     list_filter = ['status']
-    list_display = ['user', 'organisation', 'status']
-    search_fields = ['user__email', 'user__name']
+    list_display = ['organisation', 'status']
+    search_fields = ['organisation__name']


### PR DESCRIPTION
## Description
- Based on user feedback the Organisation is more important when searching claim requests. 

- Gave the organisation name priority and removed claimant information as it appeared to clutter the view rather than adding value. 


## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/125


## Relevant Screenshots 

<img width="897" alt="Screenshot 2019-11-28 at 09 44 53" src="https://user-images.githubusercontent.com/36415632/69795266-c2a35380-11c3-11ea-93c0-b465f0fcade7.png">

## Testing
- Simple UI change with built-in functionality so not a priority for testing at the moment. 

## Follow Up
- [ ] Feedback from the team. 
