### PR TITLE
enhance remove irrelevant local authority data

### DIFF
--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -660,8 +660,17 @@ $(document).ready(() => {
             $(".leaflet-pane").show();
             var name_key = result.name_key;
             result.data.forEach(function(feature){
-              var feature_name = feature.properties[`${name_key}`];
-              var geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
+              let feature_name = feature.properties[`${name_key}`];
+              // Check whether this is the local_authority dataset
+              if (name_key === "lad18nm"){
+                // Ensure only Scottish datasets are added by checking code for S prefix
+                if(feature.properties.lad18cd[0] === "S"){
+                  let geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
+                }
+              }
+              else {
+                let geoJSON = L.geoJson(feature).addTo(mymap).bindPopup(`<b>${feature_name}</b>`);
+              }
             });
           }
         });


### PR DESCRIPTION
## Description
- When visiting the service area definition page noticed that when selecting the 'local authority' data that the map was overlaid with all UK local authority geospatial features. 

- This was likely caused by the change to the smaller file size clipped data which included all UK local authority areas. 

- Updated the JS which is called to populate the map to check whether it is local authority data in which case it will only add the Scottish features. 

- As this solution requires the knowledge of the data feature names and codes it is not ideal. An alternative would be to remove the geospatial data which isn't relevant to Scotland. 

- Removing data from the dataset would have implications on location reporting. Currently, if a user erroneously adds a location outside of Scotland it is unmatched and when doing a verbose report with the local authority data it is returned as being in that region.

## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/127

## Relevant Screenshots 
<img width="602" alt="Screenshot 2019-11-22 at 17 36 06" src="https://user-images.githubusercontent.com/36415632/69819640-432f7780-11f7-11ea-91cb-72c9c3886d51.png">


<img width="775" alt="Screenshot 2019-11-28 at 15 18 28" src="https://user-images.githubusercontent.com/36415632/69819603-2f841100-11f7-11ea-8ebb-4f417c37f87c.png">


## Testing
- No automated tests were impacted and as this was a change in the JS no new automated tests were added. 

## Follow Up
- [ ] Run gulp.
- [ ] Consider removing the non-scottish geospatial data from the dataset. 
