### PR TITLE
Enhance/altsearch

### DIFF
--- a/aliss/search.py
+++ b/aliss/search.py
@@ -32,11 +32,11 @@ service_mapping = {
     'slug': {'type': 'keyword'},
     'name': {
         'type': 'text',
-        'analyzer': 'bigram_combiner'
+        'analyzer': 'english'
     },
     'description': {
         'type': 'text',
-        'analyzer': 'description_analyzer',
+        'analyzer': 'english',
     },
     'url': {'type': 'keyword'},
     'phone': {'type': 'keyword'},

--- a/aliss/search_tasks.py
+++ b/aliss/search_tasks.py
@@ -7,6 +7,7 @@ from elasticsearch_dsl import Q
 from aliss.models import Organisation, Service, Postcode
 from aliss.search import _get_connection, service_to_body, organisation_to_body, service_mapping, organisation_mapping
 
+
 index_settings = {
     'analysis': {
         "filter": {
@@ -36,7 +37,7 @@ index_settings = {
             "bigram_combiner": {
                 "tokenizer": "standard",
                 "filter": ["lowercase", "custom_shingle", "my_char_filter", "my_stop"]
-           }
+            }
         }
     }
 }
@@ -48,7 +49,8 @@ def create_service_index(connection=None):
     body = {
         'mappings': {
             'service': { 'properties': service_mapping }
-        }, 'settings': index_settings
+        },
+        'settings': index_settings
     }
     connection.indices.create(index='search', body=body)
 


### PR DESCRIPTION
## Description
- It was noted by the team that some keyword searches did not appear to return relevant results or that the relevant results were too low in the search rankings. 

- Although these results would appear irrelevant to users, when looking at the text it could be seen how the word 'dancing' could return results for 'cancer' due to the way the text was being analysed. Many similar characters and longer words have a higher margin of difference for example. 

- @digitalWestie updated the elastic search text analysis method to test whether the search could be improved. 

- To test these changes downloaded the production data, reindexed and tried a number of searches especially those which had previously had disappointing. 

- Based on the searches which were undertaken the result where vastly improved. It was found there were fewer and more accurate results.

- At this stage may be best to push the changes to staging with a request to try the new search and see whether they also see the improvements. 

## Testing
- Automated testing can be problematic based on the variability of elastic search results. Manually tested the performance with a copy of production data. 

## Follow Up
- [ ] After merging reindex.
- [ ] Request the team test the new search and assess the results. 
