### PR TITLE
Enhance/place name search error page

### DIFF
--- a/aliss/forms/search.py
+++ b/aliss/forms/search.py
@@ -15,7 +15,7 @@ class GBPostcodeDistrictField(GBPostcodeField):
         postcode = value.upper().strip()
         # Put a single space before the incode (second part).
         postcode = self.space_regex.sub(r' \1', postcode)
-        if not self.postcode_regex.search(postcode) or not self.district_pattern.search(postcode):
+        if not self.postcode_regex.search(postcode) and not self.district_pattern.search(postcode):
             raise ValidationError(self.error_messages['invalid'])
         return postcode
 

--- a/aliss/forms/search.py
+++ b/aliss/forms/search.py
@@ -15,7 +15,7 @@ class GBPostcodeDistrictField(GBPostcodeField):
         postcode = value.upper().strip()
         # Put a single space before the incode (second part).
         postcode = self.space_regex.sub(r' \1', postcode)
-        if not self.postcode_regex.search(postcode) and not self.district_pattern.search(postcode):
+        if not self.postcode_regex.search(postcode) or not self.district_pattern.search(postcode):
             raise ValidationError(self.error_messages['invalid'])
         return postcode
 

--- a/aliss/templates/search/results.html
+++ b/aliss/templates/search/results.html
@@ -42,7 +42,7 @@
     <section id="error">
       <div class="row">
         <div class="columns">
-          {% if errors and 'postcode' in errors %}
+          {% if errors and 'postcode' in errors and not searched_term %}
             <div class="copy-container">
               <h1>Sorry, ALISS is not available in your postcode.</h1>
               <p>We're always adding new services to ALISS but it seems like we've not reached your area yet. Please try again with a different postcode:</p>
@@ -51,6 +51,12 @@
             <div class="copy-container">
               <h1>Sorry, {{ request.GET.postcode }} doesn't appear to be a valid postcode.</h1>
               <p>The postcode you entered seems to be in the wrong format, please try again:</p>
+            </div>
+          {% elif searched_term %}
+            <div class="copy-container">
+              <h1>Sorry, {{ request.GET.postcode }} couldn't be matched with a postcode.</h1>
+              <p>We're always trying to make it easier for users to find services but it looks like we haven't added your searched place name yet.</p>
+              <p>Please try again with a different place name or postcode:</p>
             </div>
           {% else %}
             {% include 'partials/forms/errors.html' with form=form %}

--- a/aliss/templates/search/results.html
+++ b/aliss/templates/search/results.html
@@ -42,22 +42,22 @@
     <section id="error">
       <div class="row">
         <div class="columns">
-          {% if errors and 'postcode' in errors and not searched_term %}
+          {% if errors and 'postcode' in errors and not invalid_placename %}
             <div class="copy-container">
               <h1>Sorry, ALISS is not available in your postcode.</h1>
               <p>We're always adding new services to ALISS but it seems like we've not reached your area yet. Please try again with a different postcode:</p>
             </div>
-          {% elif invalid_area %}
-            <div class="copy-container">
-              <h1>Sorry, {{ request.GET.postcode }} doesn't appear to be a valid postcode.</h1>
-              <p>The postcode you entered seems to be in the wrong format, please try again:</p>
-            </div>
-          {% elif searched_term %}
+          {% elif invalid_placename %}
             <div class="copy-container">
               <h1>Sorry, {{ request.GET.postcode }} couldn't be matched with a postcode.</h1>
               <p>We're always trying to make it easier for users to find services but it looks like we haven't added your searched place name yet.</p>
               <p>Please try again with a different place name or postcode:</p>
             </div>
+          {% elif invalid_area %}
+          <div class="copy-container">
+            <h1>Sorry, {{ request.GET.postcode }} doesn't appear to be a valid postcode.</h1>
+            <p>The postcode you entered seems to be in the wrong format, please try again:</p>
+          </div>
           {% else %}
             {% include 'partials/forms/errors.html' with form=form %}
           {% endif %}

--- a/aliss/tests/views/test_search_view.py
+++ b/aliss/tests/views/test_search_view.py
@@ -291,5 +291,20 @@ class SearchViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<h1>Sorry, AB20 doesn't appear to be a valid postcode.</h1>", html=True)
 
+    def test_invalid_placename_search_error_page(self):
+        response = self.client.get('/search/?postcode=Argyll ')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<h1>Sorry, Argyll couldn't be matched with a postcode.</h1>", html=True)
+
+    def test_invalid_search_ALISS_not_available_error_page(self):
+        response = self.client.get('/search/?postcode=Argyll Test')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<h1>Sorry, ALISS is not available in your postcode.</h1>", html=True)
+
+    def test_invalid_postcode_error_page(self):
+        response = self.client.get('/search/?postcode=G2 4ZZ')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<h1>Sorry, G2 4ZZ doesn't appear to be a valid postcode.</h1>", html=True)
+
     def tearDown(self):
         Fixtures.organisation_teardown()

--- a/aliss/views/search.py
+++ b/aliss/views/search.py
@@ -72,6 +72,18 @@ class SearchView(MultipleObjectMixin, TemplateView):
                         ))
                 except Postcode.DoesNotExist:
                     invalid_area = search_form.cleaned_data.get('postcode', None) == None
+                    import logging
+                    logger = logging.getLogger(__name__)
+                    logger.error('Hit the search term failed.')
+                    logger.error(searched_term)
+                    if searched_term.isalpha():
+                        logger.error('Is all letters')
+                        logger.error(searched_term)
+                        return self.render_to_response(context={
+                            'form': search_form,
+                            'errors': search_form.errors,
+                            'searched_term': searched_term,
+                        })
                     return self.render_to_response(context={
                         'form': search_form,
                         'errors': search_form.errors,

--- a/aliss/views/search.py
+++ b/aliss/views/search.py
@@ -58,8 +58,17 @@ class SearchView(MultipleObjectMixin, TemplateView):
 
         else:
             searched_term = search_form.data.get('postcode')
+            valid_searched_term = None
             if searched_term:
+                valid_searched_term = searched_term.strip().replace(' ', '').isalpha()
+            import logging
+            logger = logging.getLogger(__name__)
+            # logger.error('valid_searched_term')
+            if valid_searched_term:
                 try:
+                    import logging
+                    logger = logging.getLogger(__name__)
+                    logger.error('valid_searched_term')
                     processed_search_term = searched_term.capitalize().strip()
                     lower_searched = searched_term.lower().strip()
                     matched_postcode = Postcode.objects.get(slug=lower_searched).postcode
@@ -71,30 +80,18 @@ class SearchView(MultipleObjectMixin, TemplateView):
                             searched_place=processed_search_term,
                         ))
                 except Postcode.DoesNotExist:
-                    invalid_area = search_form.cleaned_data.get('postcode', None) == None
-                    import logging
-                    logger = logging.getLogger(__name__)
-                    logger.error('Hit the search term failed.')
-                    logger.error(searched_term)
-                    if searched_term.isalpha():
-                        logger.error('Is all letters')
-                        logger.error(searched_term)
-                        return self.render_to_response(context={
-                            'form': search_form,
-                            'errors': search_form.errors,
-                            'searched_term': searched_term,
-                        })
+                    invalid_placename = True
                     return self.render_to_response(context={
                         'form': search_form,
                         'errors': search_form.errors,
-                        'invalid_area': invalid_area
+                        'invalid_placename': invalid_placename,
                     })
             else:
-                invalid_area = search_form.cleaned_data.get('postcode', None) == None
+                logger.error('help')
                 return self.render_to_response(context={
                     'form': search_form,
                     'errors': search_form.errors,
-                    'invalid_area': invalid_area
+                    'invalid_area': True,
                 })
 
 
@@ -138,6 +135,9 @@ class SearchView(MultipleObjectMixin, TemplateView):
             else:
                 self.postcode = Postcode.get_by_district(postcode)
         except Postcode.DoesNotExist:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.error('Here')
             return self.render_to_response(context={'invalid_area': True})
         return self.define_object_list_return_response()
 

--- a/aliss/views/search.py
+++ b/aliss/views/search.py
@@ -128,8 +128,6 @@ class SearchView(MultipleObjectMixin, TemplateView):
             else:
                 self.postcode = Postcode.get_by_district(postcode)
         except Postcode.DoesNotExist:
-            import logging
-            logger = logging.getLogger(__name__)
             return self.render_to_response(context={'invalid_area': True})
         return self.define_object_list_return_response()
 

--- a/aliss/views/search.py
+++ b/aliss/views/search.py
@@ -81,10 +81,11 @@ class SearchView(MultipleObjectMixin, TemplateView):
                         'invalid_placename': invalid_placename,
                     })
             else:
+                invalid_area = search_form.cleaned_data.get('postcode', None) == None
                 return self.render_to_response(context={
                     'form': search_form,
                     'errors': search_form.errors,
-                    'invalid_area': True,
+                    'invalid_area': invalid_area,
                 })
 
 

--- a/aliss/views/search.py
+++ b/aliss/views/search.py
@@ -60,15 +60,9 @@ class SearchView(MultipleObjectMixin, TemplateView):
             searched_term = search_form.data.get('postcode')
             valid_searched_term = None
             if searched_term:
-                valid_searched_term = searched_term.strip().replace(' ', '').isalpha()
-            import logging
-            logger = logging.getLogger(__name__)
-            # logger.error('valid_searched_term')
+                valid_searched_term = searched_term.strip().isalpha()
             if valid_searched_term:
                 try:
-                    import logging
-                    logger = logging.getLogger(__name__)
-                    logger.error('valid_searched_term')
                     processed_search_term = searched_term.capitalize().strip()
                     lower_searched = searched_term.lower().strip()
                     matched_postcode = Postcode.objects.get(slug=lower_searched).postcode
@@ -87,7 +81,6 @@ class SearchView(MultipleObjectMixin, TemplateView):
                         'invalid_placename': invalid_placename,
                     })
             else:
-                logger.error('help')
                 return self.render_to_response(context={
                     'form': search_form,
                     'errors': search_form.errors,
@@ -137,7 +130,6 @@ class SearchView(MultipleObjectMixin, TemplateView):
         except Postcode.DoesNotExist:
             import logging
             logger = logging.getLogger(__name__)
-            logger.error('Here')
             return self.render_to_response(context={'invalid_area': True})
         return self.define_object_list_return_response()
 


### PR DESCRIPTION
## Description
- With the introduction of placename searches without explicitly using postcodes, it became apparent that unsuccessful placename searches e.g. places which aren't supported 'Halbeath' did not have useful error pages. 

- When a placename was not correctly found the default error would be 'Sorry, ALISS is not available in your postcode."  which could give the user the wrong impression.

- If a town in Scotland was searched it would be very likely that ALISS is available in their area but they would need to access content using the standard postcode search. Or by searching a different placename. 

- To try to improve this added functionality so that when the search is not a valid postcode if there is a valid search term that could be a placename and it isn't matched a to then displaying this custom copy. 

- For example, if a user in Halbeath searches by "Halbeath" it cannot be matched to a postcode and the error message reflect that with "Sorry, Halbeath couldn't be matched with a postcode.". 

- In implementing this I began to question some of the other error messages although they are out of the scope of this work and could be discussed separately. 

## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/129
- https://github.com/Mike-Heneghan/ALISS/issues/121

## Relevant Screenshots 
### Current error for invalid placename search:
<img width="687" alt="Screenshot 2019-12-13 at 11 56 18" src="https://user-images.githubusercontent.com/36415632/70798734-ab598e00-1d9f-11ea-9b51-61022974f788.png">

### Proposed error message:
<img width="698" alt="Screenshot 2019-12-13 at 11 56 47" src="https://user-images.githubusercontent.com/36415632/70798749-b4e2f600-1d9f-11ea-832a-6959b757b633.png">

## Testing
- Added tests for the search view to more clearly check which inputs triggered which errors. 

## Follow Up
- [ ] Discuss the error message copy with the team.
- [ ] Discuss the error messages and what actions create which messages. 
