### PR TITLE
Enhance/admin user dashboard on login

### DIFF
--- a/aliss/tests/views/test_account_view.py
+++ b/aliss/tests/views/test_account_view.py
@@ -104,8 +104,8 @@ class AccountViewTestCase(TestCase):
         response = self.client.post('/account/login/', { 'username': "claimant@user.org", 'password': "passwurd" })
         self.assertRedirects(response, reverse('account_my_organisations'), status_code=302, target_status_code=200)
 
-    # Test to check that a user who has created, claimed or were last to edit an organisation with no reviews is redirected to 'My Organisations'
-    def test_user_without_services_to_review_but_with_eligible_orgs_redirect_content(self):
+    # Test to check that a user who has claimed an organisation with no reviews is redirected to 'My Organisations'
+    def test_user_without_services_to_review_but_with_claimed_org_redirect_content(self):
         self.client.logout()
         self.unreviewed_service.delete()
         claim = Claim.objects.create(
@@ -115,6 +115,22 @@ class AccountViewTestCase(TestCase):
         claim.status = 10
         claim.save()
         response = self.client.post('/account/login/', { 'username': self.org.claimed_by.email, 'password': "passwurd" }, follow=True)
+        self.assertRedirects(response, reverse('account_my_organisations'))
+        self.assertContains(response, "TestOrg")
+
+    # Test to check that a user who has created an organisation with no reviews is redirected to 'My Organisations'
+    def test_user_without_services_to_review_but_with_created_org_redirect_content(self):
+        self.client.logout()
+        self.unreviewed_service.delete()
+        response = self.client.post('/account/login/', { 'username': self.org.created_by.email, 'password': "passwurd" }, follow=True)
+        self.assertRedirects(response, reverse('account_my_organisations'))
+        self.assertContains(response, "TestOrg")
+
+    # Test to check that a user who last to update an organisation with no reviews is redirected to 'My Organisations'
+    def test_user_without_services_to_review_but_with_last_edited_org_redirect_content(self):
+        self.client.logout()
+        self.unreviewed_service.delete()
+        response = self.client.post('/account/login/', { 'username': self.org.updated_by.email, 'password': "passwurd" }, follow=True)
         self.assertRedirects(response, reverse('account_my_organisations'))
         self.assertContains(response, "TestOrg")
 

--- a/aliss/views/account.py
+++ b/aliss/views/account.py
@@ -46,7 +46,11 @@ def login_view(request, *args, **kwargs):
                 if len(user.services_to_review_ids()) > 0:
                     auth_views.login(request, *args, **kwargs)
                     return HttpResponseRedirect(reverse('account_my_reviews'))
-            return auth_views.login(request, *args, **kwargs)
+                if len(user.organisations_to_review()) > 0:
+                    auth_views.login(request, *args, **kwargs)
+                    return HttpResponseRedirect(reverse('account_my_organisations'))
+            else:
+                return auth_views.login(request, *args, **kwargs)
         except ALISSUser.DoesNotExist:
             return auth_views.login(request, *args, **kwargs)
     return auth_views.login(request, *args, **kwargs)


### PR DESCRIPTION
## Description
- Feedback from ALISS users is that they need to save as much time as possible and they sometimes it hard to find the organisations they are involved with. 

- The 'My reviews' redirect can be useful although this only occurs when a user has a service to review which is over 8 weeks old. So it doesn't all take effect. 

- Added a new redirect for users who have created, claimed or were last to update an organisation that do not have services to review. These users are redirected to the 'My organisations' page. 


## Related Issue/Issues
- https://github.com/Mike-Heneghan/ALISS/issues/131
- https://github.com/Mike-Heneghan/ALISS/issues/70

## Testing
- Added a number of tests to ensure that the redirect works for users who have created, claimed or were last to update services.  

## Follow Up
- [ ] Test the feature on staging. 
- [ ] Get feedback on the solution.  
