### PR TITLE
Stricter authorisation logic to ensure only admins and claimants can edit claimed records

### DIFF
--- a/aliss/models/location.py
+++ b/aliss/models/location.py
@@ -39,12 +39,12 @@ class Location(models.Model):
     def is_edited_by(self, user):
         if user == None or user.pk == None:
             return False
-        return (
-            user.is_staff or \
-            user.is_editor or \
-            self.organisation.created_by == user or \
-            self.organisation.claimed_by == user
-        )
+        elif user.is_staff:
+            return True
+        elif self.organisation.claimed_by == None:
+            return (user.is_editor or (self.organisation.created_by == user))
+        else:
+            return self.organisation.claimed_by == user
 
     def __str__(self):
         return self.formatted_address

--- a/aliss/models/organisation.py
+++ b/aliss/models/organisation.py
@@ -55,12 +55,12 @@ class Organisation(models.Model):
     def is_edited_by(self, user):
         if user == None or user.pk == None:
             return False
-        return (
-            user.is_staff or \
-            user.is_editor or \
-            self.created_by == user or \
-            self.claimed_by == user
-        )
+        elif user.is_staff:
+            return True
+        elif self.claimed_by == None:
+            return (user.is_editor or (self.created_by == user))
+        else:
+            return self.claimed_by == user
 
     def can_add_logo(self, user):
         if user == None or user.pk == None:

--- a/aliss/models/service.py
+++ b/aliss/models/service.py
@@ -107,12 +107,12 @@ class Service(models.Model):
     def is_edited_by(self, user):
         if user == None or user.pk == None:
             return False
-        return (
-            user.is_staff or \
-            user.is_editor or \
-            self.organisation.created_by == user or \
-            self.organisation.claimed_by == user
-        )
+        elif user.is_staff:
+            return True
+        elif self.organisation.claimed_by == None:
+            return (user.is_editor or (self.organisation.created_by == user))
+        else:
+            return self.organisation.claimed_by == user
 
     def generate_slug(self, force=False):
         name_changed = False

--- a/aliss/tests/models/test_organisation.py
+++ b/aliss/tests/models/test_organisation.py
@@ -21,16 +21,27 @@ class OrganisationTestCase(TestCase):
         ALISSUser.objects.get(email="claimant@user.org").delete()
         self.test_org_exists()
 
-    def test_is_edited_by(self):
-        o = Organisation.objects.get(name="TestOrg")
-        rep    = ALISSUser.objects.get(email="claimant@user.org")
+    def test_is_edited_by_without_claimant(self):
+        o = Fixtures.create_organisation(self.org.created_by, self.org.created_by)
         staff  = ALISSUser.objects.get(email="staff@aliss.org")
         editor = ALISSUser.objects.filter(is_editor=True).first()
         punter = ALISSUser.objects.create(name="Ms Random", email="random@random.org")
         self.assertTrue(o.is_edited_by(o.created_by))
         self.assertTrue(o.is_edited_by(staff))
         self.assertTrue(o.is_edited_by(editor))
+        self.assertFalse(o.is_edited_by(punter))
+
+    def test_is_edited_by(self):
+        o = Organisation.objects.get(name="TestOrg")
+        rep    = ALISSUser.objects.get(email="claimant@user.org")
+        staff  = ALISSUser.objects.get(email="staff@aliss.org")
+        editor = ALISSUser.objects.filter(is_editor=True).first()
+        punter = ALISSUser.objects.create(name="Ms Random", email="random@random.org")
+        self.assertEqual(rep, o.claimed_by)
+        self.assertTrue(o.is_edited_by(staff))
         self.assertTrue(o.is_edited_by(rep))
+        self.assertFalse(o.is_edited_by(o.created_by))
+        self.assertFalse(o.is_edited_by(editor))
         self.assertFalse(o.is_edited_by(punter))
 
     def test_rename_is_reflected_in_index(self):

--- a/aliss/tests/views/test_location_view.py
+++ b/aliss/tests/views/test_location_view.py
@@ -11,7 +11,7 @@ class LocationViewTestCase(TestCase):
         self.service = Fixtures.create()
         self.organisation = self.service.organisation
         self.location = self.organisation.locations.first()
-        self.client.login(username="tester@aliss.org", password="passwurd")
+        self.client.login(username="claimant@user.org", password="passwurd")
 
 
     def test_location_edit(self):

--- a/aliss/tests/views/test_location_view.py
+++ b/aliss/tests/views/test_location_view.py
@@ -16,8 +16,9 @@ class LocationViewTestCase(TestCase):
 
     def test_location_edit(self):
         path=reverse('location_edit', kwargs={'pk':self.location.pk})
-        response = self.client.get(path)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.client.get(path).status_code, 200)
+        self.client.login(username="updater@aliss.org", password='passwurd') #editor
+        self.assertEqual(self.client.get(path).status_code, 302)
 
 
     def test_location_update(self):

--- a/aliss/tests/views/test_organisation_view.py
+++ b/aliss/tests/views/test_organisation_view.py
@@ -9,7 +9,7 @@ class OrganisationViewTestCase(TestCase):
     def setUp(self):
         self.random = ALISSUser.objects.create_user("random@random.org", "passwurd")
         self.user, self.editor, self.claimant, self.staff = Fixtures.create_users()
-        self.client.login(username=self.user.email, password='passwurd')
+        self.client.login(username=self.claimant.email, password='passwurd')
         self.organisation = Fixtures.create_organisation(self.user, self.editor, self.claimant)
 
     def test_organisation_detail(self):

--- a/aliss/tests/views/test_service_view.py
+++ b/aliss/tests/views/test_service_view.py
@@ -11,17 +11,19 @@ class ServiceViewTestCase(TestCase):
     fixtures = ['categories.json', 'service_areas.json']
 
     def setUp(self):
-        self.user = ALISSUser.objects.create_user("random@random.org", "passwurd")
-        self.client.login(username='random@random.org', password='passwurd')
-        self.organisation = Fixtures.create_organisation(self.user)
+        self.user, self.editor, self.claimant, self.staff = Fixtures.create_users()
+        self.organisation = Fixtures.create_organisation(self.user, self.editor, self.claimant)
         self.service = Fixtures.create_service(self.organisation)
         self.non_edit_user = ALISSUser.objects.create_user("nonEdit@nonEdit.org", "passwurd")
+        self.client.login(username=self.claimant.email, password='passwurd')
+
 
     def test_service_detail(self):
         logged_in_response = self.client.get(reverse('service_detail_slug', kwargs={'slug':self.service.slug}))
         logged_out_response = Client().get(reverse('service_detail_slug', kwargs={'slug':self.service.slug}))
         self.assertEqual(logged_in_response.status_code, 200)
         self.assertEqual(logged_out_response.status_code, 200)
+
 
     def test_unpublished_service_detail(self):
         self.organisation.published = False
@@ -31,20 +33,42 @@ class ServiceViewTestCase(TestCase):
         self.assertEqual(logged_in_response.status_code, 200)
         self.assertEqual(logged_out_response.status_code, 302)
 
+
     def test_service_create(self):
-        x=reverse('service_create', kwargs={'pk':self.organisation.pk})
-        response = self.client.get(x)
+        create_path=reverse('service_create', kwargs={'pk':self.organisation.pk})
+        response = self.client.get(create_path)
         self.assertEqual(response.status_code, 200)
+
 
     def test_logout_service_create(self):
         self.client.logout()
         response = self.client.get(reverse('service_create', kwargs={'pk':self.organisation.pk}))
         self.assertEqual(response.status_code, 302)
 
-    def test_service_update_get(self):
-        x=reverse('service_edit', kwargs={ 'pk': self.service.pk })
-        response = self.client.get(x)
-        self.assertEqual(response.status_code, 200)
+
+    def test_service_edit(self):
+        edit_path = reverse('service_edit', kwargs={ 'pk': self.service.pk })
+        self.assertEqual(self.client.get(edit_path).status_code, 200)
+        self.client.login(username=self.staff.email, password='passwurd')
+        self.assertEqual(self.client.get(edit_path).status_code, 200)
+        self.client.login(username=self.user.email, password='passwurd')
+        self.assertEqual(self.client.get(edit_path).status_code, 302)
+        self.client.login(username=self.editor.email, password='passwurd')
+        self.assertEqual(self.client.get(edit_path).status_code, 302)
+
+
+    def test_service_edit_without_claimant(self):
+        new_org = Fixtures.create_organisation(self.organisation.created_by, self.organisation.created_by)
+        new_service = Fixtures.create_service(new_org)
+        edit_path = reverse('service_edit', kwargs={ 'pk': new_service.pk })
+        self.assertEqual(self.client.get(edit_path).status_code, 302)
+        self.client.login(username=self.user.email, password='passwurd')
+        self.assertEqual(self.client.get(edit_path).status_code, 200)
+        self.client.login(username=self.editor.email, password='passwurd')
+        self.assertEqual(self.client.get(edit_path).status_code, 200)
+        self.client.login(username=self.staff.email, password='passwurd')
+        self.assertEqual(self.client.get(edit_path).status_code, 200)
+
 
     def test_service_valid_create(self):
         category = Category.objects.first()
@@ -57,6 +81,7 @@ class ServiceViewTestCase(TestCase):
         queryset = Service.objects.filter(name='A whole new service')
         self.assertEqual(queryset.count(), 1)
         self.assertEqual(response.status_code, 302)
+
 
     def test_service_last_edited_valid_create(self):
         category = Category.objects.first()
@@ -89,8 +114,9 @@ class ServiceViewTestCase(TestCase):
         self.assertEqual(result['categories'][0]['name'], category.name)
         self.assertEqual(self.service.name, 'an updated service')
         self.assertEqual(self.service.slug, 'an-updated-service')
-        self.assertEqual(self.service.updated_by, self.user)
+        self.assertEqual(self.service.updated_by, self.claimant)
         self.assertEqual(response.status_code, 302)
+
 
     def test_service_last_edited_valid_update(self):
         old_last_edited_db = self.service.last_edited
@@ -112,6 +138,7 @@ class ServiceViewTestCase(TestCase):
         self.assertFalse(old_last_edited_db == new_last_edited_db)
         self.assertEqual(new_last_edited_db_string, new_last_edited_es)
 
+
     def test_redirect_to_org_confirm_single_service_valid_create(self):
         self.organisation.services.first().delete()
         self.assertEqual(self.organisation.services.count(), 0)
@@ -128,6 +155,7 @@ class ServiceViewTestCase(TestCase):
         self.assertRedirects(response, reverse('organisation_confirm',kwargs={'pk': self.organisation.pk}
         ))
 
+
     def test_redirect_to_org_detail_second_service_valid_create(self):
         self.assertEqual(self.organisation.services.count(), 1)
         category = Category.objects.first()
@@ -142,17 +170,21 @@ class ServiceViewTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse('organisation_detail',kwargs={'pk': self.organisation.pk}
         ))
+
+
     def test_editor_sees_edit_service_action(self):
         editor_response = self.client.get(reverse('service_detail_slug', kwargs={'slug':self.service.slug}))
         self.assertEqual(editor_response.status_code, 200)
         self.assertContains(editor_response, "My First Service")
         self.assertContains(editor_response, "Edit service")
 
+
     def test_editor_sees_delete_service_action(self):
         editor_response = self.client.get(reverse('service_detail_slug', kwargs={'slug':self.service.slug}))
         self.assertEqual(editor_response.status_code, 200)
         self.assertContains(editor_response, "My First Service")
         self.assertContains(editor_response, "Delete service")
+
 
     def test_non_editor_doesnt_see_edit_service_action(self):
         self.client.logout()
@@ -162,6 +194,7 @@ class ServiceViewTestCase(TestCase):
         self.assertContains(non_editor_response, "My First Service")
         self.assertNotContains(non_editor_response, "Edit service")
 
+
     def test_non_editor_doesnt_see_delete_service_action(self):
         self.client.logout()
         non_editor_client = self.client.login(username='nonEdit@nonEdit.com', password='passwurd')
@@ -169,6 +202,7 @@ class ServiceViewTestCase(TestCase):
         self.assertEqual(non_editor_response.status_code, 200)
         self.assertContains(non_editor_response, "My First Service")
         self.assertNotContains(non_editor_response, "Delete service")
+
 
     def test_service_at_location_delete(self):
         location_count = self.service.locations.count()
@@ -180,6 +214,7 @@ class ServiceViewTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         new_location_count = self.service.locations.count()
         self.assertEqual(0, new_location_count)
+
 
     def test_service_at_location_delete_non_editor(self):
         self.client.logout()
@@ -194,6 +229,7 @@ class ServiceViewTestCase(TestCase):
         new_location_count = self.service.locations.count()
         self.assertEqual(1, new_location_count)
 
+
     def test_service_detail_location_lat_longs_context(self):
         locations = self.service.locations.all()
         comparison_lat_long_dict = {}
@@ -205,13 +241,16 @@ class ServiceViewTestCase(TestCase):
         context_lat_longs_dict = response.context['location_lat_longs']
         self.assertEqual(comparison_lat_long_dict, context_lat_longs_dict)
 
+
     def test_service_detail_slug_embedded_map(self):
         response = self.client.get(reverse('service_detail_slug_map', kwargs={'slug':self.service.slug}))
         self.assertEqual(response.status_code, 200)
 
+
     def test_service_detail_pk_embedded_map(self):
         response = self.client.get(reverse('service_detail_map', kwargs={'pk':self.service.pk}))
         self.assertEqual(response.status_code, 200)
+
 
     def tearDown(self):
         Fixtures.organisation_teardown()


### PR DESCRIPTION
## Description
- ALISS team wanted to assure contributors who claim organisations that their records can only be edited by them
- With this change organisations and related records can only be edited by staff and approved claimant users
- Where organisations are not claimed editors and users who originally created the organisation can still update records

## Testing
- Tests coverage altered and expanded on service, organisation, location models and views. 

## Follow Up
- [ ] Test the feature on staging